### PR TITLE
EAS-476 First pass at changing app refs from notify to eas

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ CF_API ?= api.cloud.service.gov.uk
 CF_ORG ?= govuk-notify
 CF_SPACE ?= ${DEPLOY_ENV}
 CF_HOME ?= ${HOME}
-CF_APP ?= notify-admin
+CF_APP ?= eas-admin
 CF_MANIFEST_PATH ?= /tmp/manifest.yml
 $(eval export CF_HOME)
 
@@ -137,7 +137,7 @@ upload-static:
 .PHONY: cf-deploy
 cf-deploy: cf-target ## Deploys the app to Cloud Foundry
 	$(if ${CF_SPACE},,$(error Must specify CF_SPACE))
-	@cf app --guid notify-admin || exit 1
+	@cf app --guid eas-admin || exit 1
 	# cancel any existing deploys to ensure we can apply manifest (if a deploy is in progress you'll see ScaleDisabledDuringDeployment)
 	cf cancel-deployment ${CF_APP} || true
 
@@ -150,14 +150,14 @@ cf-deploy: cf-target ## Deploys the app to Cloud Foundry
 
 .PHONY: cf-deploy-prototype
 cf-deploy-prototype: cf-target ## Deploys the first prototype to Cloud Foundry
-	make -s CF_APP=notify-admin-prototype generate-manifest > ${CF_MANIFEST_PATH}
-	cf push notify-admin-prototype --strategy=rolling -f ${CF_MANIFEST_PATH}
+	make -s CF_APP=eas-admin-prototype generate-manifest > ${CF_MANIFEST_PATH}
+	cf push eas-admin-prototype --strategy=rolling -f ${CF_MANIFEST_PATH}
 	rm -f ${CF_MANIFEST_PATH}
 
 .PHONY: cf-deploy-prototype-2
 cf-deploy-prototype-2: cf-target ## Deploys the second prototype to Cloud Foundry
-	make -s CF_APP=notify-admin-prototype-2 generate-manifest > ${CF_MANIFEST_PATH}
-	cf push notify-admin-prototype-2 --strategy=rolling -f ${CF_MANIFEST_PATH}
+	make -s CF_APP=eas-admin-prototype-2 generate-manifest > ${CF_MANIFEST_PATH}
+	cf push eas-admin-prototype-2 --strategy=rolling -f ${CF_MANIFEST_PATH}
 	rm -f ${CF_MANIFEST_PATH}
 
 .PHONY: cf-rollback
@@ -171,16 +171,16 @@ cf-target: check-env-vars
 
 .PHONY: cf-failwhale-deployed
 cf-failwhale-deployed:
-	@cf app notify-admin-failwhale --guid || (echo "notify-admin-failwhale is not deployed on ${CF_SPACE}" && exit 1)
+	@cf app eas-admin-failwhale --guid || (echo "eas-admin-failwhale is not deployed on ${CF_SPACE}" && exit 1)
 
 .PHONY: enable-failwhale
 enable-failwhale: cf-target cf-failwhale-deployed ## Enable the failwhale app and disable admin
-	@cf map-route notify-admin-failwhale ${DNS_NAME} --hostname www
-	@cf unmap-route notify-admin ${DNS_NAME} --hostname www
+	@cf map-route eas-admin-failwhale ${DNS_NAME} --hostname www
+	@cf unmap-route eas-admin ${DNS_NAME} --hostname www
 	@echo "Failwhale is enabled"
 
 .PHONY: disable-failwhale
 disable-failwhale: cf-target cf-failwhale-deployed ## Disable the failwhale app and enable admin
-	@cf map-route notify-admin ${DNS_NAME} --hostname www
-	@cf unmap-route notify-admin-failwhale ${DNS_NAME} --hostname www
+	@cf map-route eas-admin ${DNS_NAME} --hostname www
+	@cf unmap-route eas-admin-failwhale ${DNS_NAME} --hostname www
 	@echo "Failwhale is disabled"

--- a/app/config.py
+++ b/app/config.py
@@ -45,7 +45,7 @@ class Config(object):
     PERMANENT_SESSION_LIFETIME = 20 * 60 * 60  # 20 hours
     SEND_FILE_MAX_AGE_DEFAULT = 365 * 24 * 60 * 60  # 1 year
     SESSION_COOKIE_HTTPONLY = True
-    SESSION_COOKIE_NAME = "notify_admin_session"
+    SESSION_COOKIE_NAME = "eas_admin_session"
     SESSION_COOKIE_SECURE = True
     SESSION_COOKIE_SAMESITE = "Lax"
     # don't send back the cookie if it hasn't been modified by the request. this means that the expiry time won't be

--- a/app/config.py
+++ b/app/config.py
@@ -26,7 +26,7 @@ class Config(object):
     DEBUG = False
     NOTIFY_LOG_PATH = os.getenv("NOTIFY_LOG_PATH")
 
-    ADMIN_CLIENT_USER_NAME = "notify-admin"
+    ADMIN_CLIENT_USER_NAME = "eas-admin"
 
     ANTIVIRUS_API_HOST = os.environ.get("ANTIVIRUS_API_HOST")
     ANTIVIRUS_API_KEY = os.environ.get("ANTIVIRUS_API_KEY")

--- a/app/templates/views/cookies.html
+++ b/app/templates/views/cookies.html
@@ -40,7 +40,7 @@
         <tbody>
             <tr>
                 <td>
-                  notify_admin_session
+                  eas_admin_session
                 </td>
                 <td width="50%">
                   Used to keep you signed in

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -1,13 +1,13 @@
 {%- set apps = {
-  'notify-admin': {
+  'eas-admin': {
     'routes': {
-      'preview': ['www.notify.works', 'notify-admin-preview.apps.internal'],
-      'staging': ['www.staging-notify.works', 'notify-admin-staging.apps.internal'],
-      'production': ['www.notifications.service.gov.uk', 'notify-admin-production.apps.internal'],
+      'preview': ['www.notify.works', 'eas-admin-preview.apps.internal'],
+      'staging': ['www.staging-notify.works', 'eas-admin-staging.apps.internal'],
+      'production': ['www.notifications.service.gov.uk', 'eas-admin-production.apps.internal'],
     }
   },
-  'notify-admin-prototype': {},
-  'notify-admin-prototype-2': {}
+  'eas-admin-prototype': {},
+  'eas-admin-prototype-2': {}
 } -%}
 
 {%- set app = apps[CF_APP] -%}

--- a/paas-failwhale/README.md
+++ b/paas-failwhale/README.md
@@ -8,7 +8,7 @@ It is deployed as an individual app and remains dormant until a route is assigne
 
 It should already be deployed, but if not you can deploy it by running
 
-    cf push notify-admin-failwhale
+    cf push eas-admin-failwhale
 
 To enable it you need to run
 

--- a/paas-failwhale/manifest.yml
+++ b/paas-failwhale/manifest.yml
@@ -1,7 +1,7 @@
 ---
 
 applications:
-  - name: notify-admin-failwhale
+  - name: eas-admin-failwhale
     no-route: true
     buildpack: staticfile_buildpack
     memory: 256M


### PR DESCRIPTION
Before successfully building the Fujitsu "developer-tooling" Docker image from which we can run the containerised development environment, the app name and service references should be updated to reflect the change in ownership from "notifications" to "emergency alerts".

Where the long name/ref is used (notifications-admin), this becomes "emergency-alerts-admin".

The shortened form (notify-admin), as used to name the service instance for example, becomes "eas-admin" (eas -> emergency alerts system).

References to the db also change from notification_api to emergency_alerts_api.