### PR TITLE
Remove autofocus from search bar elements on broadcast area search

### DIFF
--- a/app/templates/views/broadcast/areas-with-sub-areas.html
+++ b/app/templates/views/broadcast/areas-with-sub-areas.html
@@ -19,8 +19,7 @@
     target_selector='.file-list-item',
     show=show_search_form,
     form=search_form,
-    label='Search by name',
-    autofocus=True)
+    label='Search by name')
   }}
 
   {% for area in library|sort %}

--- a/app/templates/views/broadcast/areas.html
+++ b/app/templates/views/broadcast/areas.html
@@ -21,8 +21,7 @@
       target_selector='.govuk-checkboxes__item',
       show=show_search_form,
       form=search_form,
-      label='Search by name',
-      autofocus=True)
+      label='Search by name')
   }}
 
   {% call form_wrapper() %}


### PR DESCRIPTION
Removal of autofocus from search bar elements at the top of relevant screens, when choosing broadcast area. This is to improve accessibility with screen readers.