### PR TITLE
EAS-470 Add Flask config for decoupled docker deployment

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -126,7 +126,9 @@ class Development(Config):
 
 
 class Decoupled(Development):
-    API_HOST_NAME = os.environ.get("API_HOST_NAME", "http://api:6011")
+    API_HOST_NAME = "http://api:6011"
+    ADMIN_BASE_URL = "http://admin:6012"
+    TEMPLATE_PREVIEW_API_HOST = "http://api:6013"
     ANTIVIRUS_API_HOST = "http://admin:6016"
     REDIS_URL = "redis://api:6379/0"
 

--- a/app/config.py
+++ b/app/config.py
@@ -125,6 +125,12 @@ class Development(Config):
     NOTIFY_RUNTIME_PLATFORM = "local"
 
 
+class Decoupled(Development):
+    API_HOST_NAME = os.environ.get("API_HOST_NAME", "http://api:6011")
+    ANTIVIRUS_API_HOST = "http://admin:6016"
+    REDIS_URL = "redis://admin:6379/0"
+
+
 class Test(Development):
     DEBUG = True
     TESTING = True
@@ -213,6 +219,7 @@ class Sandbox(CloudFoundryConfig):
 
 configs = {
     "development": Development,
+    "decoupled": Decoupled,
     "test": Test,
     "preview": Preview,
     "staging": Staging,

--- a/app/config.py
+++ b/app/config.py
@@ -128,7 +128,7 @@ class Development(Config):
 class Decoupled(Development):
     API_HOST_NAME = os.environ.get("API_HOST_NAME", "http://api:6011")
     ANTIVIRUS_API_HOST = "http://admin:6016"
-    REDIS_URL = "redis://admin:6379/0"
+    REDIS_URL = "redis://api:6379/0"
 
 
 class Test(Development):

--- a/app/config.py
+++ b/app/config.py
@@ -126,6 +126,7 @@ class Development(Config):
 
 
 class Decoupled(Development):
+    NOTIFY_ENVIRONMENT = "decoupled"
     API_HOST_NAME = "http://api:6011"
     ADMIN_BASE_URL = "http://admin:6012"
     TEMPLATE_PREVIEW_API_HOST = "http://api:6013"


### PR DESCRIPTION
To allow the admin, api, celery and database images to run in separate containers:
- A new config class (Decoupled) has been added to the python Flask config file
- The urls assigned in the Decoupled class match the container names assigned by docker-compose (defined in a separate repository)

Note: This configuration will mainly be used as a POC to explore networking and security solutions when running EAS components in isolated containers