### PR TITLE
EAS-481 Remove reference to a specific tag on the utils repo

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -136,8 +136,8 @@ class Decoupled(Development):
 
 class ServerlessDB(Decoupled):
     NOTIFY_ENVIRONMENT = "serverlessdb"
-    ASSET_DOMAIN = "eas-app-lb-public-1779718474.eu-west-2.elb.amazonaws.com"
-    ASSET_PATH = "https://eas-app-lb-public-1779718474.eu-west-2.elb.amazonaws.com/"
+    ASSET_DOMAIN = "admin.emergency-alerts.service.gov.uk"
+    ASSET_PATH = "https://admin.emergency-alerts.service.gov.uk/"
 
 
 class Test(Development):

--- a/app/config.py
+++ b/app/config.py
@@ -136,8 +136,8 @@ class Decoupled(Development):
 
 class ServerlessDB(Decoupled):
     NOTIFY_ENVIRONMENT = "serverlessdb"
-    ASSET_DOMAIN = "admin.emergency-alerts.service.gov.uk"
-    ASSET_PATH = "https://admin.emergency-alerts.service.gov.uk/"
+    ASSET_DOMAIN = "admin.development.emergency-alerts.service.gov.uk"
+    ASSET_PATH = "https://admin.development.emergency-alerts.service.gov.uk/"
 
 
 class Test(Development):

--- a/app/config.py
+++ b/app/config.py
@@ -136,8 +136,8 @@ class Decoupled(Development):
 
 class ServerlessDB(Decoupled):
     NOTIFY_ENVIRONMENT = "serverlessdb"
-    ASSET_DOMAIN = "admin.emergency-alerts.service.gov.uk"
-    ASSET_PATH = "https://admin.emergency-alerts.service.gov.uk/"
+    ASSET_DOMAIN = "admin.developer.emergency-alerts.service.gov.uk"
+    ASSET_PATH = "https://admin.developer.emergency-alerts.service.gov.uk/"
 
 
 class Test(Development):

--- a/requirements.in
+++ b/requirements.in
@@ -29,7 +29,7 @@ pyproj==3.4.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==2.1.2
-emergency-alerts-utils @ git+https://github.com/alphagov/emergency-alerts-utils.git@60.0.0-alpha
+emergency-alerts-utils @ git+https://github.com/alphagov/emergency-alerts-utils.git
 govuk-frontend-jinja==2.3.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains

--- a/requirements.txt
+++ b/requirements.txt
@@ -122,7 +122,7 @@ mistune==0.8.4
     # via emergency-alerts-utils
 notifications-python-client==6.4.1
     # via -r requirements.in
-emergency-alerts-utils @ git+https://github.com/alphagov/emergency-alerts-utils.git@60.0.0-alpha
+emergency-alerts-utils @ git+https://github.com/alphagov/emergency-alerts-utils.git
     # via -r requirements.in
 openpyxl==3.0.10
     # via pyexcel-xlsx

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,6 +49,8 @@ docopt==0.6.2
     # via notifications-python-client
 docutils==0.16
     # via awscli
+emergency-alerts-utils @ git+https://github.com/alphagov/emergency-alerts-utils.git
+    # via -r requirements.in
 et-xmlfile==1.1.0
     # via openpyxl
 eventlet==0.33.1
@@ -58,11 +60,11 @@ fido2==1.1.0
 flask==2.2.2
     # via
     #   -r requirements.in
+    #   emergency-alerts-utils
     #   flask-login
     #   flask-redis
     #   flask-wtf
     #   gds-metrics
-    #   emergency-alerts-utils
 flask-login==0.6.2
     # via -r requirements.in
 flask-redis==0.4.0
@@ -92,15 +94,15 @@ importlib-metadata==5.1.0
 itsdangerous==2.1.2
     # via
     #   -r requirements.in
+    #   emergency-alerts-utils
     #   flask
     #   flask-wtf
-    #   emergency-alerts-utils
 jinja2==3.1.2
     # via
     #   -r requirements.in
+    #   emergency-alerts-utils
     #   flask
     #   govuk-frontend-jinja
-    #   emergency-alerts-utils
 jmespath==1.0.1
     # via
     #   boto3
@@ -121,8 +123,6 @@ markupsafe==2.1.1
 mistune==0.8.4
     # via emergency-alerts-utils
 notifications-python-client==6.4.1
-    # via -r requirements.in
-emergency-alerts-utils @ git+https://github.com/alphagov/emergency-alerts-utils.git
     # via -r requirements.in
 openpyxl==3.0.10
     # via pyexcel-xlsx
@@ -188,9 +188,9 @@ redis==4.3.4
 requests==2.28.1
     # via
     #   awscli-cwlogs
+    #   emergency-alerts-utils
     #   govuk-bank-holidays
     #   notifications-python-client
-    #   emergency-alerts-utils
 rsa==4.7.2
     # via awscli
 rtreelib==0.2.0


### PR DESCRIPTION
When the emergency-alerts-admin repository was copied from notifications-admin, a "-alpha" tag was added to hold all loosely coupled repositories (admin, api, utils) to the same version.

References to this tag can now be removed.