### PR TITLE
EAS-824 Compose status url from service name

### DIFF
--- a/Dockerfile.eas-admin
+++ b/Dockerfile.eas-admin
@@ -1,5 +1,6 @@
 FROM 388086622185.dkr.ecr.eu-west-2.amazonaws.com/emergency-alerts-base:latest
 
+ENV SERVICE=admin
 ENV VENV_ADMIN=/venv/eas-admin
 ENV ADMIN_DIR=/eas/emergency-alerts-admin
 

--- a/app/notify_client/status_api_client.py
+++ b/app/notify_client/status_api_client.py
@@ -3,11 +3,11 @@ from app.notify_client import NotifyAdminAPIClient, cache
 
 class StatusApiClient(NotifyAdminAPIClient):
     def get_status(self, *params):
-        return self.get(url="/_status", *params)
+        return self.get(url="/_api_status", *params)
 
     @cache.set("live-service-and-organisation-counts", ttl_in_seconds=3600)
     def get_count_of_live_services_and_organisations(self):
-        return self.get(url="/_status/live-service-and-organisation-counts")
+        return self.get(url="/_api_status/live-service-and-organisation-counts")
 
 
 status_api_client = StatusApiClient()

--- a/app/status/views/healthcheck.py
+++ b/app/status/views/healthcheck.py
@@ -1,11 +1,14 @@
-from flask import current_app, jsonify, request
-from notifications_python_client.errors import HTTPError
-
 from app import status_api_client, version
 from app.status import status
 
+from flask import current_app, jsonify, request
+from notifications_python_client.errors import HTTPError
+from os import environ as env_var
 
-@status.route("/_status", methods=["GET"])
+status_endpoint = "/_" + env_var.get("SERVICE") + "_status"
+
+
+@status.route(status_endpoint, methods=["GET"])
 def show_status():
     if request.args.get("elb", None) or request.args.get("simple", None):
         return jsonify(status="ok"), 200

--- a/app/status/views/healthcheck.py
+++ b/app/status/views/healthcheck.py
@@ -3,7 +3,6 @@ from app.status import status
 
 from flask import current_app, jsonify, request
 from notifications_python_client.errors import HTTPError
-from os import environ as env_var
 
 
 @status.route("/_admin_status", methods=["GET"])

--- a/app/status/views/healthcheck.py
+++ b/app/status/views/healthcheck.py
@@ -5,10 +5,8 @@ from flask import current_app, jsonify, request
 from notifications_python_client.errors import HTTPError
 from os import environ as env_var
 
-status_endpoint = "/_" + env_var.get("SERVICE") + "_status"
 
-
-@status.route(status_endpoint, methods=["GET"])
+@status.route("/_admin_status", methods=["GET"])
 def show_status():
     if request.args.get("elb", None) or request.args.get("simple", None):
         return jsonify(status="ok"), 200


### PR DESCRIPTION
To allow the health check to not only confirm a healthy container, but also that a healthy container is  running the expected image, each service (api, celery & admin) should have a named health check:

- The 'status' route is modified to be specific to the image on which each container is based
- The admin container has a health endpoint of '/_admin_status'