### PR TITLE
Change misleading duplicate sending journey h1 to Areas defined

### DIFF
--- a/app/templates/views/broadcast/preview-areas.html
+++ b/app/templates/views/broadcast/preview-areas.html
@@ -6,7 +6,7 @@
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
-  Choose where to send this alert
+  Area defined
 {% endblock %}
 
 {% block extra_stylesheets %}
@@ -23,7 +23,7 @@
 
 {% block maincolumn_content %}
 
-  {{ page_header("Choose where to send this alert") }}
+  {{ page_header("Area defined") }}
 
   {% for area in broadcast_message.areas %}
     {% if loop.first %}


### PR DESCRIPTION
The h1s of multiple pages along the sending journey share the same text - "Choose where to send this alert". This can be misleading particularly for screen-readers as it removes clarity from where in the screen flow you currently are.