### PR TITLE
Replace blinking live broadcast icon with live tag; WCAG_A

### DIFF
--- a/app/assets/stylesheets/_app.scss
+++ b/app/assets/stylesheets/_app.scss
@@ -220,28 +220,4 @@ details .arrow {
   position: relative;
   display: inline-block;
 
-  &:before {
-    content: "";
-    display: block;
-    float: right;
-    margin-top: 1px;
-    margin-left: 5px;
-    border: none;
-    background: govuk-colour("red");
-    width: 19px;
-    height: 19px;
-    border-radius: 50%;
-    animation: live-pulse 1.5s infinite;
-  }
-
-  &--left {
-
-    &:before {
-      float: left;
-      margin-left: 0;
-      margin-right: 10px;
-    }
-
-  }
-
 }

--- a/app/assets/stylesheets/govuk-frontend/_all.scss
+++ b/app/assets/stylesheets/govuk-frontend/_all.scss
@@ -23,6 +23,7 @@ $govuk-assets-path: "/static/";
 @import "govuk/components/inset-text/index";
 @import "govuk/components/textarea/index";
 @import "govuk/components/summary-list/index";
+@import "govuk/components/tag/index";
 
 @import "govuk/utilities/all";
 @import "govuk/overrides/all";

--- a/app/assets/stylesheets/govuk-frontend/overrides.scss
+++ b/app/assets/stylesheets/govuk-frontend/overrides.scss
@@ -34,3 +34,7 @@ $notify-secondary-button-hover-colour: govuk-shade(govuk-colour("light-grey"), 1
     background-color: $notify-secondary-button-hover-colour;
   }
 }
+
+.govuk-tag.broadcast-tag {
+  background-color: govuk-colour("red");
+}

--- a/app/templates/views/broadcast/partials/dashboard-table.html
+++ b/app/templates/views/broadcast/partials/dashboard-table.html
@@ -1,4 +1,5 @@
 {% from "components/table.html" import list_table, field, right_aligned_field_heading, row_heading %}
+{% from "govuk_frontend_jinja/components/tag/macro.html" import govukTag %}
 
 <div class="ajax-block-container js-mark-focus-on-parent" data-classes-to-persist="js-child-has-focus">
 {% for item in broadcasts|sort|reverse|list %}
@@ -20,7 +21,11 @@
         </p>
       {% elif item.status == 'broadcasting' %}
         <p class="govuk-body live-broadcast file-list-status">
-          Live since {{ item.starts_at|format_datetime_relative }}
+          {{ govukTag ({
+            'text': 'live',
+            'classes': 'govuk-!-margin-right-2 broadcast-tag'
+          }) }}
+          since {{ item.starts_at|format_datetime_relative }}
         </p>
       {% else %}
         <p class="govuk-body govuk-hint file-list-status">

--- a/app/templates/views/broadcast/view-message.html
+++ b/app/templates/views/broadcast/view-message.html
@@ -1,5 +1,6 @@
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "govuk_frontend_jinja/components/details/macro.html" import govukDetails %}
+{% from "govuk_frontend_jinja/components/tag/macro.html" import govukTag %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/banner.html" import banner %}
 {% from "components/page-header.html" import page_header %}
@@ -155,7 +156,11 @@
 
     {% if broadcast_message.status == 'broadcasting' %}
       <p class="govuk-body govuk-!-margin-bottom-2 live-broadcast live-broadcast--left">
-        Live since {{ broadcast_message.starts_at|format_datetime_relative }}&ensp;
+        {{ govukTag ({
+          'text': 'live',
+          'classes': 'govuk-!-margin-right-2 broadcast-tag'
+        }) }}
+        since {{ broadcast_message.starts_at|format_datetime_relative }}&ensp;
         {%- if not hide_stop_link %}
           <a href="{{ url_for('.cancel_broadcast_message', service_id=current_service.id, broadcast_message_id=broadcast_message.id) }}" class="destructive-link destructive-link--no-visited-state">Stop sending</a>
         {% endif %}


### PR DESCRIPTION
The blinking icon presented beside a live broadcast breaks WCAG_A. It has been replaced with a govuk tag element, saying "LIVE" instead of the blinking icon.