### PR TITLE
Alert text truncation

### DIFF
--- a/app/assets/stylesheets/_app.scss
+++ b/app/assets/stylesheets/_app.scss
@@ -220,28 +220,4 @@ details .arrow {
   position: relative;
   display: inline-block;
 
-  &:before {
-    content: "";
-    display: block;
-    float: right;
-    margin-top: 1px;
-    margin-left: 5px;
-    border: none;
-    background: govuk-colour("red");
-    width: 19px;
-    height: 19px;
-    border-radius: 50%;
-    animation: live-pulse 1.5s infinite;
-  }
-
-  &--left {
-
-    &:before {
-      float: left;
-      margin-left: 0;
-      margin-right: 10px;
-    }
-
-  }
-
 }

--- a/app/assets/stylesheets/govuk-frontend/_all.scss
+++ b/app/assets/stylesheets/govuk-frontend/_all.scss
@@ -23,6 +23,7 @@ $govuk-assets-path: "/static/";
 @import "govuk/components/inset-text/index";
 @import "govuk/components/textarea/index";
 @import "govuk/components/summary-list/index";
+@import "govuk/components/tag/index";
 
 @import "govuk/utilities/all";
 @import "govuk/overrides/all";

--- a/app/assets/stylesheets/govuk-frontend/overrides.scss
+++ b/app/assets/stylesheets/govuk-frontend/overrides.scss
@@ -34,3 +34,7 @@ $notify-secondary-button-hover-colour: govuk-shade(govuk-colour("light-grey"), 1
     background-color: $notify-secondary-button-hover-colour;
   }
 }
+
+.govuk-tag.broadcast-tag {
+  background-color: govuk-colour("red");
+}

--- a/app/assets/stylesheets/views/dashboard.scss
+++ b/app/assets/stylesheets/views/dashboard.scss
@@ -60,25 +60,15 @@
 
     & > .file-list-hint-large,
     & > .file-list-status {
-      // fallback for browsers that don't support flexbox - let `text-align: justify` on parent
-      // and making children inline mimic `justify-content: space-between`
-      display: inline-block;
 
       // This simulates a 50% column in a govuk grid on smaller screens
       // govuk grid columns go to 100% width on smaller screens
       width: 100%;
 
-      // This simulates a 50% column in a govuk grid on larger screens
-      // as with govuk grid, this includes a gap between columns to ensure the contents
-      // are separated by a space
-      @include govuk-media-query($from: tablet) {
-        max-width: calc(50% - #{$govuk-gutter-half});
-      }
     }
 
     & > .file-list-status {
       overflow: hidden; // old IE hack to make it vertically line up with the hint
-      margin-bottom: 0; // cancel margin-bottom from .govuk-hint class
     }
 
     & > .file-list-hint-large {
@@ -96,7 +86,6 @@
   &-filename {
     @include govuk-font(19, $weight: bold);
     display: block;
-    white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
     padding-bottom: 30px;
@@ -107,13 +96,12 @@
 
   &-filename-large {
     @include govuk-font(24, $weight: bold);
-    display: block;
-    white-space: nowrap;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
     overflow: hidden;
     text-overflow: ellipsis;
-    padding-bottom: 30px;
     padding-top: 10px;
-    margin-bottom: -30px;
     margin-top: -10px;
   }
 
@@ -131,26 +119,27 @@
 
   &-hint {
     @include govuk-font(16);
-    display: block;
     color: $govuk-secondary-text-colour;
+    display: -webkit-box;
     overflow: hidden;
-    white-space: nowrap;
     text-overflow: ellipsis;
-    max-width: 580px;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2; /* number of lines to show */
+    max-width: 60ch;
   }
 
   &-hint-large {
     @include govuk-font(19);
     display: block;
     color: $govuk-secondary-text-colour;
+    display: -webkit-box;
     overflow: hidden;
-    white-space: nowrap;
     text-overflow: ellipsis;
-    max-width: 580px;
-  }
-
-  &-status {
-    text-align: right;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2; /* number of lines to show */
+    max-width: 60ch;
   }
 
 }

--- a/app/templates/views/broadcast/partials/dashboard-table.html
+++ b/app/templates/views/broadcast/partials/dashboard-table.html
@@ -1,4 +1,5 @@
 {% from "components/table.html" import list_table, field, right_aligned_field_heading, row_heading %}
+{% from "govuk_frontend_jinja/components/tag/macro.html" import govukTag %}
 
 <div class="ajax-block-container js-mark-focus-on-parent" data-classes-to-persist="js-child-has-focus">
 {% for item in broadcasts|sort|reverse|list %}
@@ -20,7 +21,11 @@
         </p>
       {% elif item.status == 'broadcasting' %}
         <p class="govuk-body live-broadcast file-list-status">
-          Live since {{ item.starts_at|format_datetime_relative }}
+          {{ govukTag ({
+            'text': 'live',
+            'classes': 'govuk-!-margin-right-2 broadcast-tag'
+          }) }}
+          since {{ item.starts_at|format_datetime_relative }}
         </p>
       {% else %}
         <p class="govuk-body govuk-hint file-list-status">

--- a/app/templates/views/broadcast/view-message.html
+++ b/app/templates/views/broadcast/view-message.html
@@ -1,5 +1,6 @@
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "govuk_frontend_jinja/components/details/macro.html" import govukDetails %}
+{% from "govuk_frontend_jinja/components/tag/macro.html" import govukTag %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/banner.html" import banner %}
 {% from "components/page-header.html" import page_header %}
@@ -155,7 +156,11 @@
 
     {% if broadcast_message.status == 'broadcasting' %}
       <p class="govuk-body govuk-!-margin-bottom-2 live-broadcast live-broadcast--left">
-        Live since {{ broadcast_message.starts_at|format_datetime_relative }}&ensp;
+        {{ govukTag ({
+          'text': 'live',
+          'classes': 'govuk-!-margin-right-2 broadcast-tag'
+        }) }}
+        since {{ broadcast_message.starts_at|format_datetime_relative }}&ensp;
         {%- if not hide_stop_link %}
           <a href="{{ url_for('.cancel_broadcast_message', service_id=current_service.id, broadcast_message_id=broadcast_message.id) }}" class="destructive-link destructive-link--no-visited-state">Stop sending</a>
         {% endif %}


### PR DESCRIPTION
As part of EAS-84, the displayed alert text and description have been elongated to fill two lines visually, without trimming the content that is read out to screenreader users (As it is not trimmed from the HTML)