### PR TITLE
New Alert Validation Error Summary

### DIFF
--- a/app/templates/views/broadcast/write-new-broadcast.html
+++ b/app/templates/views/broadcast/write-new-broadcast.html
@@ -4,6 +4,7 @@
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/textbox.html" import textbox %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+{% from "components/error-summary.html" import errorSummary %}
 
 {% block service_page_title %}
   New alert
@@ -15,6 +16,8 @@
 {% endblock %}
 
 {% block maincolumn_content %}
+
+  {{ errorSummary(form) }}
 
   {{ page_header('New alert')}}
 

--- a/app/templates/views/edit-broadcast-template.html
+++ b/app/templates/views/edit-broadcast-template.html
@@ -4,6 +4,7 @@
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+{% from "components/error-summary.html" import errorSummary %}
 
 {% block service_page_title %}
   {{ heading_action }} template
@@ -16,6 +17,8 @@
 {% endblock %}
 
 {% block maincolumn_content %}
+
+  {{ errorSummary(form) }}
 
   {{ page_header('{} template'.format(heading_action)) }}
 


### PR DESCRIPTION
An accessibility issue was raised with regards to the use of a govuk error summary component when the new broadcast/template forms do not pass validation. This is to ensure that screenreaders are alerted to the presence of a validation issue, since the error summary component appears at the top of the page and will therefore immediately inform the user of what needs to be changed in order for the form to be valid.