### PR TITLE
Broadcast Form Back Link State Retention

### DIFF
--- a/app/models/broadcast_message.py
+++ b/app/models/broadcast_message.py
@@ -86,6 +86,17 @@ class BroadcastMessage(JSONModel):
         )
 
     @classmethod
+    def update_from_content(cls, *, service_id, broadcast_message_id, content, reference):
+        broadcast_message_api_client.update_broadcast_message(
+            service_id=service_id,
+            broadcast_message_id=broadcast_message_id,
+            data={
+                "reference": reference,
+                "content": content,
+            },
+        )
+
+    @classmethod
     def from_id(cls, broadcast_message_id, *, service_id):
         return cls(
             broadcast_message_api_client.get_broadcast_message(

--- a/app/status/views/healthcheck.py
+++ b/app/status/views/healthcheck.py
@@ -1,8 +1,8 @@
-from app import status_api_client, version
-from app.status import status
-
 from flask import current_app, jsonify, request
 from notifications_python_client.errors import HTTPError
+
+from app import status_api_client, version
+from app.status import status
 
 
 @status.route("/_admin_status", methods=["GET"])

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -11,6 +11,7 @@ from tests import broadcast_message_json, sample_uuid, user_json
 from tests.app.broadcast_areas.custom_polygons import BRISTOL, SKYE
 from tests.conftest import (
     SERVICE_ONE_ID,
+    SERVICE_TWO_ID,
     create_active_user_approve_broadcasts_permissions,
     create_active_user_create_broadcasts_permissions,
     create_active_user_view_permissions,
@@ -1465,6 +1466,66 @@ def test_preview_broadcast_areas_has_back_link_with_uuid(
         broadcast_message_id=str(uuid.UUID(int=0)),
         **expected_back_link_extra_kwargs,
     )
+
+
+def test_write_new_broadcast_content_from_uuid_is_displayed_before_live(
+    mocker,
+    client_request,
+    service_one,
+    fake_uuid,
+    active_user_create_broadcasts_permission,
+):
+    mocker.patch(
+        "app.broadcast_message_api_client.get_broadcast_message",
+        return_value=broadcast_message_json(
+            id_=fake_uuid,
+            reference="Emergency broadcast",
+            content="Emergency broadcast content",
+            template_id=fake_uuid,
+            created_by_id=fake_uuid,
+            service_id=SERVICE_ONE_ID,
+            status="draft",
+        )
+    )
+    service_one["permissions"] += ["broadcast"]
+    client_request.login(active_user_create_broadcasts_permission)
+    page = client_request.get(
+        "main.write_new_broadcast", service_id=SERVICE_ONE_ID, broadcast_message_id=fake_uuid
+    )
+
+    assert normalize_spaces(page.select_one("textarea").text) == "Emergency broadcast content"
+
+
+def test_write_new_broadcast_only_displays_from_this_service(
+    mocker,
+    client_request,
+    service_one,
+    service_two,
+    active_user_create_broadcasts_permission,
+):
+    service_one["permissions"] += ["broadcast"]
+    client_request.login(active_user_create_broadcasts_permission)
+    page = client_request.get(
+        "main.write_new_broadcast", service_id=SERVICE_TWO_ID, broadcast_message_id=str(uuid.UUID(int=0)),
+        _expected_status=403,
+    )
+    assert normalize_spaces(page.select_one("h1").text) == "You’re not allowed to see this page"
+
+
+def test_write_new_broadcast_does_not_display_alerts_in_broadcast(
+    mocker,
+    client_request,
+    service_one,
+    mock_get_live_broadcast_message,
+    fake_uuid,
+    active_user_create_broadcasts_permission,
+):
+    service_one["permissions"] += ["broadcast"]
+    client_request.login(active_user_create_broadcasts_permission)
+    page = client_request.get(
+        "main.write_new_broadcast", service_id=SERVICE_ONE_ID, broadcast_message_id=fake_uuid
+    )
+    assert normalize_spaces(page.select_one("input").text) == ""
 
 
 def test_choose_broadcast_sub_area_page_for_county_shows_links_for_districts(

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -1434,6 +1434,7 @@ def test_write_new_broadcast_does_update_when_broadcast_exists(
     client_request,
     service_one,
     active_user_create_broadcasts_permission,
+    mock_create_broadcast_message,
     mock_update_broadcast_message,
 ):
     mocker.patch(
@@ -1462,6 +1463,7 @@ def test_write_new_broadcast_does_update_when_broadcast_exists(
         },
     )
 
+    assert not mock_create_broadcast_message.called
     assert mock_update_broadcast_message.called
 
 

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -1429,6 +1429,42 @@ def test_choose_broadcast_sub_area_page_for_district_has_back_link(
     )
 
 
+def test_write_new_broadcast_does_update_when_broadcast_exists(
+    mocker,
+    client_request,
+    service_one,
+    active_user_create_broadcasts_permission,
+    mock_update_broadcast_message,
+):
+    mocker.patch(
+        "app.broadcast_message_api_client.get_broadcast_message",
+        return_value=broadcast_message_json(
+            id_=str(uuid.UUID(int=0)),
+            service_id=SERVICE_ONE_ID,
+            created_by_id=active_user_create_broadcasts_permission["id"],
+            finishes_at=None,
+            status="draft",
+        )
+    )
+    service_one["permissions"] += ["broadcast"]
+    client_request.login(active_user_create_broadcasts_permission)
+    client_request.get(
+        "main.write_new_broadcast", service_id=SERVICE_ONE_ID, broadcast_message_id=str(uuid.UUID(int=0))
+    )
+
+    client_request.post(
+        ".write_new_broadcast",
+        service_id=SERVICE_ONE_ID,
+        broadcast_message_id=str(uuid.UUID(int=0)),
+        _data={
+            "name": "Emergency broadcast",
+            "template_content": "Broadcast content",
+        },
+    )
+
+    assert mock_update_broadcast_message.called
+
+
 @pytest.mark.parametrize(
     "expected_back_link_url, expected_back_link_extra_kwargs",
     [

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -515,10 +515,10 @@ def test_broadcast_dashboard(
     assert len(page.select(".ajax-block-container")) == len(page.select("h1")) == 1
 
     assert [normalize_spaces(row.text) for row in page.select(".ajax-block-container")[0].select(".file-list")] == [
-        "Half an hour ago This is a test Waiting for approval England Scotland",
-        "Hour and a half ago This is a test Waiting for approval England Scotland",
-        "Example template This is a test Live since today at 2:20am England Scotland",
-        "Example template This is a test Live since today at 1:20am England Scotland",
+        "Half an hour ago This is a test Waiting for approval Area: England Scotland",
+        "Hour and a half ago This is a test Waiting for approval Area: England Scotland",
+        "Example template This is a test live since today at 2:20am Area: England Scotland",
+        "Example template This is a test live since today at 1:20am Area: England Scotland",
     ]
 
 
@@ -602,7 +602,8 @@ def test_broadcast_dashboard_json(
     assert json_response.keys() == {"current_broadcasts"}
 
     assert "Waiting for approval" in json_response["current_broadcasts"]
-    assert "Live since today at 2:20am" in json_response["current_broadcasts"]
+    assert "live" in json_response["current_broadcasts"]
+    assert "since today at 2:20am" in json_response["current_broadcasts"]
 
 
 @pytest.mark.parametrize(
@@ -629,8 +630,8 @@ def test_previous_broadcasts_page(
     assert normalize_spaces(page.select_one("main h1").text) == "Past alerts"
     assert len(page.select(".ajax-block-container")) == 1
     assert [normalize_spaces(row.text) for row in page.select(".ajax-block-container")[0].select(".file-list")] == [
-        "Example template This is a test Yesterday at 2:20pm England Scotland",
-        "Example template This is a test Yesterday at 2:20am England Scotland",
+        "Example template This is a test Yesterday at 2:20pm Area: England Scotland",
+        "Example template This is a test Yesterday at 2:20am Area: England Scotland",
     ]
 
 
@@ -658,7 +659,7 @@ def test_rejected_broadcasts_page(
     assert normalize_spaces(page.select_one("main h1").text) == "Rejected alerts"
     assert len(page.select(".ajax-block-container")) == 1
     assert [normalize_spaces(row.text) for row in page.select(".ajax-block-container")[0].select(".file-list")] == [
-        "Example template This is a test Today at 1:20am England Scotland",
+        "Example template This is a test Today at 1:20am Area: England Scotland",
     ]
 
 
@@ -743,7 +744,7 @@ def test_write_new_broadcast_page(
     assert normalize_spaces(page.select_one("label[for=name]").text) == "Reference"
     assert page.select_one("input[type=text]")["name"] == "name"
 
-    assert normalize_spaces(page.select_one("label[for=template_content]").text) == "Message"
+    assert normalize_spaces(page.select_one("label[for=template_content]").text) == "Alert message"
     assert page.select_one("textarea")["name"] == "template_content"
     assert page.select_one("textarea")["data-notify-module"] == "enhanced-textbox"
     assert page.select_one("textarea")["data-highlight-placeholders"] == "false"
@@ -1427,6 +1428,45 @@ def test_choose_broadcast_sub_area_page_for_district_has_back_link(
     )
 
 
+@pytest.mark.parametrize(
+    "expected_back_link_url, expected_back_link_extra_kwargs",
+    [
+        (".write_new_broadcast", {}),
+    ],
+)
+def test_preview_broadcast_areas_has_back_link_with_uuid(
+    mocker,
+    client_request,
+    service_one,
+    active_user_create_broadcasts_permission,
+    expected_back_link_url,
+    expected_back_link_extra_kwargs,
+):
+    mocker.patch(
+        "app.broadcast_message_api_client.get_broadcast_message",
+        return_value=broadcast_message_json(
+            id_=str(uuid.UUID(int=0)),
+            service_id=SERVICE_ONE_ID,
+            created_by_id=active_user_create_broadcasts_permission["id"],
+            finishes_at=None,
+            status="pending-approval",
+        )
+    )
+    service_one["permissions"] += ["broadcast"]
+    client_request.login(active_user_create_broadcasts_permission)
+    page = client_request.get(
+        "main.preview_broadcast_areas", service_id=SERVICE_ONE_ID, broadcast_message_id=str(uuid.UUID(int=0))
+    )
+    assert normalize_spaces(page.select_one("h1").text) == "Area defined"
+    back_link = page.select_one(".govuk-back-link")
+    assert back_link["href"] == url_for(
+        expected_back_link_url,
+        service_id=SERVICE_ONE_ID,
+        broadcast_message_id=str(uuid.UUID(int=0)),
+        **expected_back_link_extra_kwargs,
+    )
+
+
 def test_choose_broadcast_sub_area_page_for_county_shows_links_for_districts(
     client_request,
     service_one,
@@ -1756,7 +1796,7 @@ def test_start_broadcasting(
                 "finishes_at": "2020-02-23T23:23:23.000000",
             },
             [
-                "Live since 20 February at 8:20pm Stop sending",
+                "live since 20 February at 8:20pm Stop sending",
                 "Created by Alice and approved by Bob.",
                 "Broadcasting stops tomorrow at 11:23pm.",
             ],
@@ -1769,7 +1809,7 @@ def test_start_broadcasting(
                 "finishes_at": "2020-02-23T23:23:23.000000",
             },
             [
-                "Live since 20 February at 8:20pm Stop sending",
+                "live since 20 February at 8:20pm Stop sending",
                 "Created from an API call and approved by Alice.",
                 "Broadcasting stops tomorrow at 11:23pm.",
             ],


### PR DESCRIPTION
As part of an audit into accessibility issues with the admin application, it was identified that clicking the back link on the form for creating a new broadcast does not retain state as one would expect it to. When returning to the form for adding "reference" and "content" fields to the database, their respective values are lost, effectively restarting the creation of an alert.
This PR fixes this issue in the interest of accessibility and user experience, by passing the broadcast message id into the screen as a query parameter if applicable, and allowing those fields to be updated following initial creation (see https://github.com/alphagov/emergency-alerts-api/pull/12).