### PR TITLE
EAS-447 Containerized build image

### DIFF
--- a/Dockerfile.eas-admin
+++ b/Dockerfile.eas-admin
@@ -8,9 +8,8 @@ ENV ADMIN_DIR=/eas/emergency-alerts-admin
 COPY . $ADMIN_DIR
 
 # Run emergency-alerts-admin
-RUN $PYTHON_VERSION -m venv $VENV_ADMIN
-RUN . $VENV_ADMIN/bin/activate && pip3 install wheel
-RUN cd $ADMIN_DIR && . $VENV_ADMIN/bin/activate && make bootstrap
+RUN $PYTHON_VERSION -m venv $VENV_ADMIN && . $VENV_ADMIN/bin/activate && \
+    pip3 install wheel && cd $ADMIN_DIR && make bootstrap
 
 # Create a blank configuration file
 RUN echo "" > $ADMIN_DIR/environment.sh

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -272,7 +272,7 @@ def make_session_permanent():
     """
     Make sessions permanent. By permanent, we mean "admin app sets when it expires". Normally the cookie would expire
     whenever you close the browser. With this, the session expiry is set in `config['PERMANENT_SESSION_LIFETIME']`
-    (20 hours) and is refreshed after every request. IE: you will be logged out after twenty hours of inactivity.
+    (30 minutes) and is refreshed after every request. IE: you will be logged out after twenty hours of inactivity.
 
     We don't _need_ to set this every request (it's saved within the cookie itself under the `_permanent` flag), only
     when you first log in/sign up/get invited/etc, but we do it just to be safe. For more reading, check here:

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -272,7 +272,7 @@ def make_session_permanent():
     """
     Make sessions permanent. By permanent, we mean "admin app sets when it expires". Normally the cookie would expire
     whenever you close the browser. With this, the session expiry is set in `config['PERMANENT_SESSION_LIFETIME']`
-    (30 minutes) and is refreshed after every request. IE: you will be logged out after twenty hours of inactivity.
+    (30 minutes) and is refreshed after every request. IE: you will be logged out after 30 minutes of inactivity.
 
     We don't _need_ to set this every request (it's saved within the cookie itself under the `_permanent` flag), only
     when you first log in/sign up/get invited/etc, but we do it just to be safe. For more reading, check here:

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -272,7 +272,7 @@ def make_session_permanent():
     """
     Make sessions permanent. By permanent, we mean "admin app sets when it expires". Normally the cookie would expire
     whenever you close the browser. With this, the session expiry is set in `config['PERMANENT_SESSION_LIFETIME']`
-    (30 minutes) and is refreshed after every request. IE: you will be logged out after 30 minutes of inactivity.
+    (30 minutes). IE: you will be logged 30 minutes after authentication.
 
     We don't _need_ to set this every request (it's saved within the cookie itself under the `_permanent` flag), only
     when you first log in/sign up/get invited/etc, but we do it just to be safe. For more reading, check here:

--- a/app/config.py
+++ b/app/config.py
@@ -42,7 +42,7 @@ class Config(object):
     HTTP_PROTOCOL = "http"
     NOTIFY_APP_NAME = "admin"
     NOTIFY_LOG_LEVEL = "DEBUG"
-    PERMANENT_SESSION_LIFETIME = 20 * 60 * 60  # 20 hours
+    PERMANENT_SESSION_LIFETIME = 30 * 60  # 30 minutes
     SEND_FILE_MAX_AGE_DEFAULT = 365 * 24 * 60 * 60  # 1 year
     SESSION_COOKIE_HTTPONLY = True
     SESSION_COOKIE_NAME = "notify_admin_session"


### PR DESCRIPTION
As another step toward self-contained Fargate deployed microservices, the following changes have been made to the Emergency Alerts Admin repo:

- Consolidate RUN commands in Dockerfile to reduce layer count
- Reduce the session timeout from 20 hours to 30 minutes.