### PR TITLE
EAS-305 Adjust titles to those expected by unit tests

### DIFF
--- a/app/templates/views/broadcast/tour/live/1.html
+++ b/app/templates/views/broadcast/tour/live/1.html
@@ -4,7 +4,7 @@
 {% extends "admin_template.html" %}
 
 {% block per_page_title %}
-  You’ve been invited to send live emergency alerts.
+  Welcome
 {% endblock %}
 
 {% set mainClasses = "govuk-!-padding-top-0 govuk-!-padding-bottom-0" %}

--- a/app/templates/views/broadcast/tour/live/2.html
+++ b/app/templates/views/broadcast/tour/live/2.html
@@ -4,7 +4,7 @@
 {% extends "admin_template.html" %}
 
 {% block per_page_title %}
-  You can always go back to training mode by clicking ‘Switch service’ in the top right.
+  Switch service
 {% endblock %}
 
 {% set mainClasses = "govuk-!-padding-top-0 govuk-!-padding-bottom-0" %}


### PR DESCRIPTION
Adjust page titles to match the H1 title in the body - this fixes the 4 broken unit tests