### PR TITLE
EAS-576 Replace hard-coded account number with env var

### DIFF
--- a/Dockerfile.eas-admin
+++ b/Dockerfile.eas-admin
@@ -1,4 +1,4 @@
-FROM 388086622185.dkr.ecr.eu-west-2.amazonaws.com/eas-app-base:latest
+FROM $ECS_ACCOUNT_NUMBER.dkr.ecr.eu-west-2.amazonaws.com/eas-app-base:latest
 
 ENV SERVICE=admin
 ENV VENV_ADMIN=/venv/eas-admin


### PR DESCRIPTION
Build script determines account number at build time - use this environment variable instead of hard-coding the account number.