### PR TITLE
EAS-940 Remove redundant config

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -134,12 +134,6 @@ class Decoupled(Development):
     REDIS_URL = "redis://api.ecs.local:6379/0"
 
 
-class ServerlessDB(Decoupled):
-    NOTIFY_ENVIRONMENT = "serverlessdb"
-    ASSET_DOMAIN = "admin.development.emergency-alerts.service.gov.uk"
-    ASSET_PATH = "https://admin.development.emergency-alerts.service.gov.uk/"
-
-
 class Test(Development):
     DEBUG = True
     TESTING = True


### PR DESCRIPTION
Remove redundant config class to standardise the notify environment variable across containers.