### PR TITLE
Add visually hidden label to 'remove' buttons

### DIFF
--- a/app/templates/views/broadcast/preview-areas.html
+++ b/app/templates/views/broadcast/preview-areas.html
@@ -34,12 +34,12 @@
             {{ area.name }}
             <a class="area-list-item-remove govuk-button" data-module="govuk-button" role="button" href="{{ url_for('.remove_broadcast_area', service_id=current_service.id, broadcast_message_id=broadcast_message.id, area_slug=area.id) }}">
               <svg id="area-list-item-remove__icon" width="11" height="11" viewbox="0 0 10 10" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg">
-                <title id="area__{{ loop.index }}">Remove {{ area.name }}</title>
                 <g transform="rotate(45),translate(1, -6)">
                   <line stroke-width="1.75" id="svg_1" y2="0" x2="6" y1="12" x1="6" stroke="currentColor" fill="none"/>
                   <line stroke-width="1.75" id="svg_3" y2="6" x2="0" y1="6" x1="12" stroke="currentColor" fill="none"/>
                 </g>
               </svg>
+              <span class="govuk-visually-hidden">Remove {{ area.name }}</span>
             </a>
           </li>
         {% endfor %}


### PR DESCRIPTION
Hi! 👋🏻, I noticed in your presentation on the accessibility fixes you did (:clap:) that the advice DAC gave to fix the buttons to remove areas left them without an accessible name.

They were right to say the svg of an 'X' in the button should be hidden from assistive tech' but didn't explain that doing so would leave the button without any content and so no accessible name.

## Evidence of the problem

I knocked up [a before and after example](https://button-with-svg-a11y.glitch.me/) and tested it with Microsoft's Accessibility Insights for Web tool. The current button got:

Title: WCAG 2.4.4,WCAG 4.1.2: Ensures links have discernible text

Issue: Ensures links have discernible text (link-name - https://accessibilityinsights.io/info-examples/web/link-name)

How to fix: 

Fix all of the following:
- Element is in tab order and does not have accessible text

Fix any of the following:
- Element does not have text that is visible to screen readers
- aria-label attribute does not exist or is empty
- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
- Element has no title attribute

## This fix

This adds some hidden text to the button which gives it an accessible name (aka accessible text).