### PR TITLE
EAS-627 Switch to Notify API for email/sms transport

### DIFF
--- a/app/assets/error_pages/5xx.html
+++ b/app/assets/error_pages/5xx.html
@@ -55,7 +55,7 @@
             </span>
 
             <span class="govuk-header__product-name">
-              Notify
+              Emergency Alerts
             </span>
 
           </a>

--- a/app/config.py
+++ b/app/config.py
@@ -129,7 +129,7 @@ class Decoupled(Development):
     NOTIFY_ENVIRONMENT = "decoupled"
     API_HOST_NAME = "http://api.ecs.local:6011"
     ADMIN_BASE_URL = "http://admin.ecs.local:6012"
-    ADMIN_EXTERNAL_URL = f"https://admin.{os.environ.get('ENVIRONMENT')}.emergency-alerts.service.gov.uk/"
+    ADMIN_EXTERNAL_URL = f"https://admin.{os.environ.get('ENVIRONMENT')}.emergency-alerts.service.gov.uk"
     TEMPLATE_PREVIEW_API_HOST = "http://api.ecs.local:6013"
     ANTIVIRUS_API_HOST = "http://admin.ecs.local:6016"
     REDIS_URL = "redis://api.ecs.local:6379/0"
@@ -152,7 +152,7 @@ class Test(Development):
     ANTIVIRUS_API_HOST = "https://test-antivirus"
     ANTIVIRUS_API_KEY = "test-antivirus-secret"
     ANTIVIRUS_ENABLED = True
-
+    ADMIN_EXTERNAL_URL = f"https://admin.{os.environ.get('ENVIRONMENT')}.emergency-alerts.service.gov.uk"
     ASSET_DOMAIN = "static.example.com"
     ASSET_PATH = "https://static.example.com/"
 

--- a/app/config.py
+++ b/app/config.py
@@ -129,6 +129,7 @@ class Decoupled(Development):
     NOTIFY_ENVIRONMENT = "decoupled"
     API_HOST_NAME = "http://api.ecs.local:6011"
     ADMIN_BASE_URL = "http://admin.ecs.local:6012"
+    ADMIN_EXTERNAL_URL = "https://admin.development.emergency-alerts.service.gov.uk/"
     TEMPLATE_PREVIEW_API_HOST = "http://api.ecs.local:6013"
     ANTIVIRUS_API_HOST = "http://admin.ecs.local:6016"
     REDIS_URL = "redis://api.ecs.local:6379/0"

--- a/app/config.py
+++ b/app/config.py
@@ -136,8 +136,7 @@ class Decoupled(Development):
 
 class ServerlessDB(Decoupled):
     NOTIFY_ENVIRONMENT = "serverlessdb"
-    ASSET_DOMAIN = "admin.development.emergency-alerts.service.gov.uk"
-    ASSET_PATH = "https://admin.development.emergency-alerts.service.gov.uk/"
+    ADMIN_BASE_URL = "https://admin.development.emergency-alerts.service.gov.uk"
 
 
 class Test(Development):

--- a/app/config.py
+++ b/app/config.py
@@ -129,7 +129,7 @@ class Decoupled(Development):
     NOTIFY_ENVIRONMENT = "decoupled"
     API_HOST_NAME = "http://api.ecs.local:6011"
     ADMIN_BASE_URL = "http://admin.ecs.local:6012"
-    ADMIN_EXTERNAL_URL = "https://admin.development.emergency-alerts.service.gov.uk/"
+    ADMIN_EXTERNAL_URL = f"https://admin.{os.environ.get('ENVIRONMENT')}.emergency-alerts.service.gov.uk/"
     TEMPLATE_PREVIEW_API_HOST = "http://api.ecs.local:6013"
     ANTIVIRUS_API_HOST = "http://admin.ecs.local:6016"
     REDIS_URL = "redis://api.ecs.local:6379/0"

--- a/app/notify_client/invite_api_client.py
+++ b/app/notify_client/invite_api_client.py
@@ -9,7 +9,6 @@ class InviteApiClient(NotifyAdminAPIClient):
     def init_app(self, app):
         super().init_app(app)
 
-        # self.admin_url = app.config["ADMIN_BASE_URL"]
         self.admin_url = app.config["ADMIN_EXTERNAL_URL"]
 
     def create_invite(self, invite_from_id, service_id, email_address, permissions, auth_type, folder_permissions):

--- a/app/notify_client/invite_api_client.py
+++ b/app/notify_client/invite_api_client.py
@@ -9,7 +9,8 @@ class InviteApiClient(NotifyAdminAPIClient):
     def init_app(self, app):
         super().init_app(app)
 
-        self.admin_url = app.config["ADMIN_BASE_URL"]
+        # self.admin_url = app.config["ADMIN_BASE_URL"]
+        self.admin_url = app.config["ADMIN_EXTERNAL_URL"]
 
     def create_invite(self, invite_from_id, service_id, email_address, permissions, auth_type, folder_permissions):
         data = {

--- a/app/notify_client/org_invite_api_client.py
+++ b/app/notify_client/org_invite_api_client.py
@@ -5,7 +5,8 @@ class OrgInviteApiClient(NotifyAdminAPIClient):
     def init_app(self, app):
         super().init_app(app)
 
-        self.admin_url = app.config["ADMIN_BASE_URL"]
+        # self.admin_url = app.config["ADMIN_BASE_URL"]
+        self.admin_url = app.config["ADMIN_EXTERNAL_URL"]
 
     def create_invite(self, invite_from_id, org_id, email_address):
         data = {

--- a/app/notify_client/org_invite_api_client.py
+++ b/app/notify_client/org_invite_api_client.py
@@ -5,7 +5,6 @@ class OrgInviteApiClient(NotifyAdminAPIClient):
     def init_app(self, app):
         super().init_app(app)
 
-        # self.admin_url = app.config["ADMIN_BASE_URL"]
         self.admin_url = app.config["ADMIN_EXTERNAL_URL"]
 
     def create_invite(self, invite_from_id, org_id, email_address):

--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -17,7 +17,6 @@ ALLOWED_ATTRIBUTES = {
 class UserApiClient(NotifyAdminAPIClient):
     def init_app(self, app):
         super().init_app(app)
-        # self.admin_url = app.config["ADMIN_BASE_URL"]
         self.admin_url = app.config["ADMIN_EXTERNAL_URL"]
 
     def register_user(self, name, email_address, mobile_number, password, auth_type):

--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -17,7 +17,8 @@ ALLOWED_ATTRIBUTES = {
 class UserApiClient(NotifyAdminAPIClient):
     def init_app(self, app):
         super().init_app(app)
-        self.admin_url = app.config["ADMIN_BASE_URL"]
+        # self.admin_url = app.config["ADMIN_BASE_URL"]
+        self.admin_url = app.config["ADMIN_EXTERNAL_URL"]
 
     def register_user(self, name, email_address, mobile_number, password, auth_type):
         data = {

--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -130,7 +130,7 @@
 
   {{ govukHeader({
     "homepageUrl": url_for('main.show_accounts_or_dashboard'),
-    "productName": "Notify",
+    "productName": "Emergency Alerts",
     "navigation": navigation,
     "navigationClasses": "govuk-header__navigation--end",
     "assetsPath": asset_path + "images"

--- a/app/webauthn_server.py
+++ b/app/webauthn_server.py
@@ -5,7 +5,8 @@ from fido2.webauthn import PublicKeyCredentialRpEntity
 
 
 def init_app(app):
-    base_url = urlparse(app.config["ADMIN_BASE_URL"])
+    # base_url = urlparse(app.config["ADMIN_BASE_URL"])
+    base_url = urlparse(app.config["ADMIN_EXTERNAL_URL"])
     verify_origin_callback = None
 
     # stub verification in dev (to avoid need for HTTPS)

--- a/app/webauthn_server.py
+++ b/app/webauthn_server.py
@@ -5,7 +5,6 @@ from fido2.webauthn import PublicKeyCredentialRpEntity
 
 
 def init_app(app):
-    # base_url = urlparse(app.config["ADMIN_BASE_URL"])
     base_url = urlparse(app.config["ADMIN_EXTERNAL_URL"])
     verify_origin_callback = None
 

--- a/paas-failwhale/index.html
+++ b/paas-failwhale/index.html
@@ -54,7 +54,7 @@
             </span>
 
             <span class="govuk-header__product-name">
-              Notify
+              Emergency Alerts
             </span>
 
           </a>

--- a/tests/app/main/views/test_webauthn_credentials.py
+++ b/tests/app/main/views/test_webauthn_credentials.py
@@ -1,5 +1,4 @@
 import base64
-import os
 from unittest.mock import ANY, Mock
 
 import pytest
@@ -67,7 +66,6 @@ def test_begin_register_returns_encoded_options(
     )
 
     webauthn_options = cbor.decode(response.data)["publicKey"]
-    print(webauthn_options)
     assert webauthn_options["attestation"] == "direct"
     assert webauthn_options["timeout"] == 30_000
 

--- a/tests/app/main/views/test_webauthn_credentials.py
+++ b/tests/app/main/views/test_webauthn_credentials.py
@@ -1,4 +1,5 @@
 import base64
+import os
 from unittest.mock import ANY, Mock
 
 import pytest
@@ -66,6 +67,7 @@ def test_begin_register_returns_encoded_options(
     )
 
     webauthn_options = cbor.decode(response.data)["publicKey"]
+    print(webauthn_options)
     assert webauthn_options["attestation"] == "direct"
     assert webauthn_options["timeout"] == 30_000
 
@@ -79,7 +81,7 @@ def test_begin_register_returns_encoded_options(
 
     relying_party_options = webauthn_options["rp"]
     assert relying_party_options["name"] == "GOV.UK Notify"
-    assert relying_party_options["id"] == "webauthn.io"
+    assert relying_party_options["id"] == f"admin.{os.environ.get('ENVIRONMENT')}.emergency-alerts.service.gov.uk"
 
 
 def test_begin_register_includes_existing_credentials(

--- a/tests/app/main/views/test_webauthn_credentials.py
+++ b/tests/app/main/views/test_webauthn_credentials.py
@@ -81,7 +81,7 @@ def test_begin_register_returns_encoded_options(
 
     relying_party_options = webauthn_options["rp"]
     assert relying_party_options["name"] == "GOV.UK Notify"
-    assert relying_party_options["id"] == f"admin.{os.environ.get('ENVIRONMENT')}.emergency-alerts.service.gov.uk"
+    assert relying_party_options["id"] == "webauthn.io"
 
 
 def test_begin_register_includes_existing_credentials(

--- a/tests/app/notify_client/test_invite_client.py
+++ b/tests/app/notify_client/test_invite_client.py
@@ -1,3 +1,4 @@
+import os
 from unittest.mock import ANY
 
 from app import invite_api_client
@@ -42,7 +43,7 @@ def test_client_creates_invite(
             "service": "67890",
             "created_by": ANY,
             "permissions": "send_emails,send_letters,send_texts",
-            "invite_link_host": "http://localhost:6012",
+            "invite_link_host": f"https://admin.{os.environ.get('ENVIRONMENT')}.emergency-alerts.service.gov.uk",
             "folder_permissions": [fake_uuid],
         },
     )

--- a/tests/app/notify_client/test_user_client.py
+++ b/tests/app/notify_client/test_user_client.py
@@ -1,3 +1,4 @@
+import os
 import uuid
 from unittest.mock import Mock, call
 
@@ -91,7 +92,7 @@ def test_client_passes_admin_url_when_sending_email_auth(
         "/user/{}/email-code".format(fake_uuid),
         data={
             "to": "ignored@example.com",
-            "email_auth_link_host": "http://localhost:6012",
+            "email_auth_link_host": f"https://admin.{os.environ.get('ENVIRONMENT')}.emergency-alerts.service.gov.uk",
         },
     )
 
@@ -318,7 +319,7 @@ def test_reset_password(
         "/user/reset-password",
         data={
             "email": "test@example.com",
-            "admin_base_url": "http://localhost:6012",
+            "admin_base_url": f"https://admin.{os.environ.get('ENVIRONMENT')}.emergency-alerts.service.gov.uk",
         },
     )
 
@@ -335,6 +336,6 @@ def test_send_registration_email(
         f"/user/{fake_uuid}/email-verification",
         data={
             "to": "test@example.com",
-            "admin_base_url": "http://localhost:6012",
+            "admin_base_url": f"https://admin.{os.environ.get('ENVIRONMENT')}.emergency-alerts.service.gov.uk",
         },
     )

--- a/tests/app/test_webauthn_server.py
+++ b/tests/app/test_webauthn_server.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 
 from app import webauthn_server
@@ -7,8 +8,7 @@ from app import webauthn_server
 def app_with_mock_config(mocker):
     app = mocker.Mock()
 
-    app.config = {"ADMIN_EXTERNAL_URL": "https://www.notify.works", "NOTIFY_ENVIRONMENT": "development"}
-
+    app.config = {"ADMIN_EXTERNAL_URL": f"https://admin.{os.environ.get('ENVIRONMENT')}.emergency-alerts.service.gov.uk", "NOTIFY_ENVIRONMENT": "development"}
     return app
 
 
@@ -25,4 +25,4 @@ def test_server_relying_party_id(
     mocker,
 ):
     webauthn_server.init_app(app_with_mock_config)
-    assert app_with_mock_config.webauthn_server.rp.id == "www.notify.works"
+    assert app_with_mock_config.webauthn_server.rp.id == f"admin.{os.environ.get('ENVIRONMENT')}.emergency-alerts.service.gov.uk"

--- a/tests/app/test_webauthn_server.py
+++ b/tests/app/test_webauthn_server.py
@@ -1,4 +1,5 @@
 import os
+
 import pytest
 
 from app import webauthn_server
@@ -8,7 +9,10 @@ from app import webauthn_server
 def app_with_mock_config(mocker):
     app = mocker.Mock()
 
-    app.config = {"ADMIN_EXTERNAL_URL": f"https://admin.{os.environ.get('ENVIRONMENT')}.emergency-alerts.service.gov.uk", "NOTIFY_ENVIRONMENT": "development"}
+    app.config = {
+        "ADMIN_EXTERNAL_URL": f"https://admin.{os.environ.get('ENVIRONMENT')}.emergency-alerts.service.gov.uk",
+        "NOTIFY_ENVIRONMENT": "development",
+    }
     return app
 
 
@@ -25,4 +29,5 @@ def test_server_relying_party_id(
     mocker,
 ):
     webauthn_server.init_app(app_with_mock_config)
-    assert app_with_mock_config.webauthn_server.rp.id == f"admin.{os.environ.get('ENVIRONMENT')}.emergency-alerts.service.gov.uk"
+    rp_id = "admin.{}.emergency-alerts.service.gov.uk"
+    assert app_with_mock_config.webauthn_server.rp.id == rp_id.format(os.environ.get("ENVIRONMENT"))

--- a/tests/app/test_webauthn_server.py
+++ b/tests/app/test_webauthn_server.py
@@ -7,7 +7,7 @@ from app import webauthn_server
 def app_with_mock_config(mocker):
     app = mocker.Mock()
 
-    app.config = {"ADMIN_BASE_URL": "https://www.notify.works", "NOTIFY_ENVIRONMENT": "development"}
+    app.config = {"ADMIN_EXTERNAL_URL": "https://www.notify.works", "NOTIFY_ENVIRONMENT": "development"}
 
     return app
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2960,6 +2960,7 @@ def webauthn_dev_server(notify_admin, mocker):
     overrides = {
         "NOTIFY_ENVIRONMENT": "development",
         "ADMIN_BASE_URL": "https://webauthn.io",
+        "ADMIN_EXTERNAL_URL": "https://webauthn.io",
     }
 
     with set_config_values(notify_admin, overrides):


### PR DESCRIPTION
- The new domain used for Emergency Alerts has been updated in code; unit tests need to be updated to reflect this change
- The landing page has its header text changed from 'Notify' to 'Emergency Alerts'