### PR TITLE
EAS-487 Parse the domain in url creation

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -129,7 +129,8 @@ class Decoupled(Development):
     NOTIFY_ENVIRONMENT = "decoupled"
     API_HOST_NAME = "http://api.ecs.local:6011"
     ADMIN_BASE_URL = "http://admin.ecs.local:6012"
-    ADMIN_EXTERNAL_URL = f"https://admin.{os.environ.get('ENVIRONMENT')}.emergency-alerts.service.gov.uk"
+    SUBDOMAIN = f"{os.environ.get('ENVIRONMENT')}." if os.environ.get("ENVIRONMENT") != "production" else ""
+    ADMIN_EXTERNAL_URL = f"https://admin.{SUBDOMAIN}emergency-alerts.service.gov.uk"
     TEMPLATE_PREVIEW_API_HOST = "http://api.ecs.local:6013"
     ANTIVIRUS_API_HOST = "http://admin.ecs.local:6016"
     REDIS_URL = "redis://api.ecs.local:6379/0"
@@ -152,7 +153,8 @@ class Test(Development):
     ANTIVIRUS_API_HOST = "https://test-antivirus"
     ANTIVIRUS_API_KEY = "test-antivirus-secret"
     ANTIVIRUS_ENABLED = True
-    ADMIN_EXTERNAL_URL = f"https://admin.{os.environ.get('ENVIRONMENT')}.emergency-alerts.service.gov.uk"
+    SUBDOMAIN = f"{os.environ.get('ENVIRONMENT')}." if os.environ.get("ENVIRONMENT") != "production" else ""
+    ADMIN_EXTERNAL_URL = f"https://admin.{SUBDOMAIN}emergency-alerts.service.gov.uk"
     ASSET_DOMAIN = "static.example.com"
     ASSET_PATH = "https://static.example.com/"
 


### PR DESCRIPTION
When generating the URL that is passed out in the invitation, password-reset and other emails, the ENVIRONMENT should be checked to make sure the "production" domain isn't embedded in the URL.