### PR TITLE
EAS-994 Fix unit tests targetting deprecated options & code

### DIFF
--- a/app/main/views/add_service.py
+++ b/app/main/views/add_service.py
@@ -5,7 +5,7 @@ from notifications_python_client.errors import HTTPError
 from app import service_api_client
 from app.formatters import email_safe
 from app.main import main
-from app.main.forms import CreateNhsServiceForm, CreateServiceForm
+from app.main.forms import CreateServiceForm
 from app.models.service import Service
 from app.utils.user import user_is_gov_user, user_is_logged_in
 

--- a/tests/app/main/views/service_settings/test_service_setting_permissions.py
+++ b/tests/app/main/views/service_settings/test_service_setting_permissions.py
@@ -58,18 +58,6 @@ def test_service_set_permission_does_not_exist_for_broadcast_permission(
     [
         (
             [],
-            "inbound_sms",
-            "True",
-            ["inbound_sms"],
-        ),
-        (
-            ["inbound_sms"],
-            "inbound_sms",
-            "False",
-            [],
-        ),
-        (
-            [],
             "email_auth",
             "True",
             ["email_auth"],
@@ -77,18 +65,6 @@ def test_service_set_permission_does_not_exist_for_broadcast_permission(
         (
             ["email_auth"],
             "email_auth",
-            "False",
-            [],
-        ),
-        (
-            [],
-            "international_letters",
-            "True",
-            ["international_letters"],
-        ),
-        (
-            ["international_letters"],
-            "international_letters",
             "False",
             [],
         ),
@@ -131,18 +107,6 @@ def test_service_set_permission(
     [
         ({"restricted": True}, ".service_switch_live", {}, "Live Off Change service status"),
         ({"restricted": False}, ".service_switch_live", {}, "Live On Change service status"),
-        (
-            {"permissions": ["sms"]},
-            ".service_set_inbound_number",
-            {},
-            "Receive inbound SMS Off Change your settings for Receive inbound SMS",
-        ),
-        (
-            {"permissions": ["letter"]},
-            ".service_set_permission",
-            {"permission": "international_letters"},
-            "Send international letters Off Change your settings for Send international letters",
-        ),
     ],
 )
 def test_service_setting_toggles_show(
@@ -194,24 +158,6 @@ def test_service_settings_links_for_archived_service(
         len([link for link in links if link.get("href") == url_for(".archive_service", service_id=service_one["id"])])
         == 0
     )
-
-
-@pytest.mark.parametrize(
-    "permissions,permissions_text,visible",
-    [
-        ("sms", "inbound SMS", True),
-        ("inbound_sms", "inbound SMS", False),  # no sms parent permission
-        # also test no permissions set
-        ("", "inbound SMS", False),
-    ],
-)
-def test_service_settings_doesnt_show_option_if_parent_permission_disabled(
-    get_service_settings_page, service_one, permissions, permissions_text, visible
-):
-    service_one["permissions"] = [permissions]
-    page = get_service_settings_page()
-    cells = page.select("td")
-    assert any(cell for cell in cells if permissions_text in cell.text) is visible
 
 
 def test_normal_user_doesnt_see_any_platform_admin_settings(

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -113,7 +113,6 @@ def mock_get_service_settings_page_common(
                 "Email branding GOV.UK Change email branding (admin view)",
                 "Letter branding Not set Change letter branding (admin view)",
                 "Custom data retention Email – 7 days Change data retention",
-                "Receive inbound SMS Off Change your settings for Receive inbound SMS",
                 "Email authentication Off Change your settings for Email authentication",
                 "Emergency alerts Off Change your settings for emergency alerts",
             ],

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -202,42 +202,6 @@ def test_add_service_has_to_choose_org_type(
 
 
 @pytest.mark.parametrize(
-    "email_address",
-    (
-        "test@nhs.net",
-        "test@nhs.uk",
-        "test@example.NhS.uK",
-        "test@EXAMPLE.NHS.NET",
-    ),
-)
-def test_get_should_only_show_nhs_org_types_radios_if_user_has_nhs_email(
-    client_request,
-    mocker,
-    api_user_active,
-    email_address,
-):
-    api_user_active["email_address"] = email_address
-    client_request.login(api_user_active)
-    mocker.patch(
-        "app.organisations_client.get_organisation_by_domain",
-        return_value=None,
-    )
-    page = client_request.get("main.add_service")
-    assert page.select_one("h1").text.strip() == "About your service"
-    assert page.select_one("input[name=name]").get("value") is None
-    assert [label.text.strip() for label in page.select(".govuk-radios__item label")] == [
-        "NHS – central government agency or public body",
-        "NHS Trust or Clinical Commissioning Group",
-        "GP practice",
-    ]
-    assert [radio["value"] for radio in page.select(".govuk-radios__item input")] == [
-        "nhs_central",
-        "nhs_local",
-        "nhs_gp",
-    ]
-
-
-@pytest.mark.parametrize(
     "organisation_type, free_allowance",
     [
         ("central", 150_000),


### PR DESCRIPTION
Some code/options that references deprecated services were causing unit tests to fail - this PR fixes unit tests by selectively removing test code that targets obsolete features.