### PR TITLE
Content changes to auth flows for EAS

### DIFF
--- a/app/assets/error_pages/5xx.html
+++ b/app/assets/error_pages/5xx.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <title>
-       Sorry, there is a problem with the service – GOV.UK Emergency Alerts
+       Sorry, there’s a problem with the service – GOV.UK Emergency Alerts
     </title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c" />
@@ -69,13 +69,18 @@
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-full">
             <h1 class="govuk-heading-l govuk-!-padding-top-7">
-              Sorry, there is a problem with the service
+              Sorry, there is a problem with the GOV.UK Emergency Alerts service
             </h1>
             <p class="govuk-body">
               Try again later.
             </p>
             <p class="govuk-body">
-              <br/>To report a problem, email <a href="mailto:emergency-alerts-support@digital.cabinet-office.gov.uk">emergency-alerts-support@digital.cabinet-office.gov.uk</a>
+              If you have any questions, email the Emergency Alerts team.
+            </p>
+            <p class="govuk-body">
+              Emergency Alerts team
+              <br/><a class="govuk-link govuk-link--no-visited-state" href="mailto:emergency-alerts-support@digital.cabinet-office.gov.uk">emergency-alerts-support@digital.cabinet-office.gov.uk</a>
+            </p>
           </div>
         </div>
       </main>

--- a/app/templates/error/500.html
+++ b/app/templates/error/500.html
@@ -3,14 +3,18 @@
 {% block maincolumn_content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="heading-large">
-        Sorry, there’s a problem with GOV.UK Emergency Alerts
+      <h1 class="govuk-heading-l">
+        Sorry, there is a problem with the GOV.UK Emergency Alerts service
       </h1>
       <p class="govuk-body">
         Try again later.
       </p>
       <p class="govuk-body">
-        To report a problem, email <a class="govuk-link govuk-link--no-visited-state" href="mailto:emergency-alerts-support@digital.cabinet-office.gov.uk">emergency-alerts-support@digital.cabinet-office.gov.uk</a>
+        If you have any questions, email the Emergency Alerts team.
+      </p>
+      <p class="govuk-body">
+        Emergency Alerts team
+        <br/><a class="govuk-link govuk-link--no-visited-state" href="mailto:emergency-alerts-support@digital.cabinet-office.gov.uk">emergency-alerts-support@digital.cabinet-office.gov.uk</a>
       </p>
     </div>
   </div>

--- a/app/templates/views/platform-admin/_base_template.html
+++ b/app/templates/views/platform-admin/_base_template.html
@@ -17,8 +17,7 @@
             ('Organisations', url_for('main.organisations')),
             ('Live services', url_for('main.live_services')),
             ('Trial mode services', url_for('main.trial_services')),
-            ('Clear cache', url_for('main.clear_cache')),
-            ('API integration', url_for('.api_keys', service_id=current_service.id))
+            ('Clear cache', url_for('main.clear_cache'))
           ] %}
             <li>
               <a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline" href="{{ url }}">

--- a/app/templates/views/two-factor-email.html
+++ b/app/templates/views/two-factor-email.html
@@ -10,8 +10,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="heading-large">{{ title }}</h1>
-    <p class="govuk-body">We’ve emailed you a link to sign in to Notify.</p>
-    <p class="govuk-body">Clicking the link will open Notify in a new browser window, so you can close this one.</p>
+    <p class="govuk-body">We’ve emailed you a link to sign in to Emergency Alerts.</p>
+    <p class="govuk-body">Clicking the link will open Emergency Alerts in a new browser window, so you can close this one.</p>
     {{ page_footer(
       secondary_link=url_for('main.email_not_received', next=redirect_url),
       secondary_link_text='Not received an email?'

--- a/tests/app/main/test_errorhandlers.py
+++ b/tests/app/main/test_errorhandlers.py
@@ -48,7 +48,7 @@ def test_csrf_returns_400(client_request, mocker):
         _test_page_title=False,
     )
 
-    assert page.select_one("h1").string.strip() == "Sorry, there’s a problem with GOV.UK Emergency Alerts"
+    assert page.select_one("h1").string.strip() == "Sorry, there is a problem with the GOV.UK Emergency Alerts service"
     assert (
         page.select_one("title").string.strip() == "Sorry, there’s a problem with the service – GOV.UK Emergency Alerts"
     )
@@ -68,7 +68,7 @@ def test_csrf_redirects_to_sign_in_page_if_not_signed_in(client_request, mocker)
 def test_405_returns_something_went_wrong_page(client_request, mocker):
     page = client_request.post_url("/", _expected_status=405)
 
-    assert page.select_one("h1").string.strip() == "Sorry, there’s a problem with GOV.UK Emergency Alerts"
+    assert page.select_one("h1").string.strip() == "Sorry, there is a problem with the GOV.UK Emergency Alerts service"
     assert (
         page.select_one("title").string.strip() == "Sorry, there’s a problem with the service – GOV.UK Emergency Alerts"
     )


### PR DESCRIPTION
This amends the content to satisfy the requirements of EAS-1191, and the remaining part of EAS-1121 (changes to 5xx screens) - primarily replacing instances of "Notify" with "Emergency Alerts" etc., and updating contact information.