### PR TITLE
EAS-1259 Not Live Informative Banner

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -95,6 +95,7 @@ from app.notify_client.complaint_api_client import complaint_api_client
 from app.notify_client.contact_list_api_client import contact_list_api_client
 from app.notify_client.email_branding_client import email_branding_client
 from app.notify_client.events_api_client import events_api_client
+from app.notify_client.feature_toggle_api_client import feature_toggle_api_client
 from app.notify_client.inbound_number_client import inbound_number_client
 from app.notify_client.invite_api_client import invite_api_client
 from app.notify_client.job_api_client import job_api_client
@@ -170,6 +171,7 @@ def create_app(application):
         complaint_api_client,
         email_branding_client,
         events_api_client,
+        feature_toggle_api_client,
         inbound_number_client,
         invite_api_client,
         job_api_client,
@@ -249,8 +251,11 @@ def init_app(application):
 
     @application.context_processor
     def inject_global_template_variables():
+        service_is_not_live_flag = feature_toggle_api_client.find_feature_toggle_by_name("service_is_not_live")
+        flag_enabled = service_is_not_live_flag.get("is_enabled", False)
         return {
             "asset_path": application.config["ASSET_PATH"],
+            "live_service_notice": service_is_not_live_flag["display_html"] if flag_enabled else None,
             "header_colour": application.config["HEADER_COLOUR"],
             "asset_url": asset_fingerprinter.get_url,
             "font_paths": font_paths,

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -251,7 +251,7 @@ def init_app(application):
 
     @application.context_processor
     def inject_global_template_variables():
-        service_is_not_live_flag = feature_toggle_api_client.find_feature_toggle_by_name("service_is_not_live")
+        service_is_not_live_flag = feature_toggle_api_client.get_feature_toggle("service_is_not_live")
         flag_enabled = service_is_not_live_flag.get("is_enabled", False)
         return {
             "asset_path": application.config["ASSET_PATH"],

--- a/app/assets/stylesheets/govuk-frontend/_all.scss
+++ b/app/assets/stylesheets/govuk-frontend/_all.scss
@@ -12,6 +12,7 @@ $govuk-assets-path: "/static/";
 // section replacing @import "components/all", specifying which components to include
 @import "govuk/components/skip-link/index";
 @import "govuk/components/header/index";
+@import "govuk/components/notification-banner/index";
 @import "govuk/components/footer/index";
 @import "govuk/components/back-link/index";
 @import "govuk/components/button/index";

--- a/app/assets/stylesheets/govuk-frontend/overrides.scss
+++ b/app/assets/stylesheets/govuk-frontend/overrides.scss
@@ -26,6 +26,11 @@ $notify-secondary-button-hover-colour: govuk-shade(govuk-colour("light-grey"), 1
 
 }
 
+.govuk-notification-banner {
+  margin-top: 15px;
+  margin-bottom: 15px;
+}
+
 // Make column headings smaller to prevent wrapping
 .govuk-footer__heading {
   @include govuk-font($size: 19, $weight: bold);

--- a/app/notify_client/feature_toggle_api_client.py
+++ b/app/notify_client/feature_toggle_api_client.py
@@ -1,0 +1,9 @@
+from app.notify_client import NotifyAdminAPIClient
+
+
+class FeatureToggleApiClient(NotifyAdminAPIClient):
+    def find_feature_toggle_by_name(self, feature_toggle_name):
+        return self.get("/feature-toggle", params={"feature_toggle_name": feature_toggle_name})
+
+
+feature_toggle_api_client = FeatureToggleApiClient()

--- a/app/notify_client/feature_toggle_api_client.py
+++ b/app/notify_client/feature_toggle_api_client.py
@@ -2,7 +2,7 @@ from app.notify_client import NotifyAdminAPIClient
 
 
 class FeatureToggleApiClient(NotifyAdminAPIClient):
-    def find_feature_toggle_by_name(self, feature_toggle_name):
+    def get_feature_toggle(self, feature_toggle_name):
         return self.get("/feature-toggle", params={"feature_toggle_name": feature_toggle_name})
 
 

--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -1,5 +1,6 @@
 {% extends "govuk_frontend_jinja/template.html"%}
 {% from "components/banner.html" import banner %}
+{%- from "govuk_frontend_jinja/components/notification-banner/macro.html" import govukNotificationBanner -%}
 {% from "components/cookie-banner.html" import cookie_banner %}
 
 {% block headIcons %}
@@ -110,6 +111,14 @@
     "navigationClasses": "govuk-header__navigation--end",
     "assetsPath": asset_path + "images"
   }) }}
+  {% if live_service_notice %}
+    <div class="govuk-width-container">
+      {{ govukNotificationBanner({
+        'titleText': "IMPORTANT",
+        'html': live_service_notice
+      }) }}
+    </div>
+  {% endif %}
 {% endblock %}
 
 {% block footer %}

--- a/app/templates/views/accessibility_statement.html
+++ b/app/templates/views/accessibility_statement.html
@@ -59,7 +59,7 @@
   <h2 class="heading-medium" id="enforcement-procedure">Enforcement procedure</h2>
 
   <p class="govuk-body">
-    The Equality and Human Rights Commission (EHRC) is responsible for enforcing the <a class="govuk-link govuk-link--no-visited-state" href="https://www.legislation.gov.uk/uksi/2018/852/contents/made">Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 </a>.
+    The Equality and Human Rights Commission (EHRC) is responsible for enforcing the <a class="govuk-link govuk-link--no-visited-state" href="https://www.legislation.gov.uk/uksi/2018/852/contents/made">Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018</a>.
   </p>
 
   <p class="govuk-body">
@@ -69,7 +69,7 @@
   <h2 class="heading-medium" id="technical-information">Technical information about accessibility of this website</h2>
 
   <p class="govuk-body">
-    GDS is committed to making its website accessible in accordance with the <a class="govuk-link govuk-link--no-visited-state" href="https://www.legislation.gov.uk/uksi/2018/852/contents/made">Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 </a>.
+    GDS is committed to making its website accessible in accordance with the <a class="govuk-link govuk-link--no-visited-state" href="https://www.legislation.gov.uk/uksi/2018/852/contents/made">Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018</a>.
   </p>
 
   <p class="govuk-body">

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -28,8 +28,8 @@ class TestClient(FlaskClient):
             session["current_session_id"] = model_user.current_session_id
             session["user_id"] = model_user.id
         if mocker:
-            mocker.patch("app.user_api_client.get_user", return_value=user)
             mocker.patch("app.feature_toggle_api_client.get_feature_toggle", return_value={})
+            mocker.patch("app.user_api_client.get_user", return_value=user)
         if mocker and service:
             with self.session_transaction() as session:
                 session["service_id"] = service["id"]
@@ -605,6 +605,7 @@ def validate_route_permission(
 ):
     usr["permissions"][str(service["id"])] = permissions
     usr["services"] = [service["id"]]
+    mocker.patch("app.feature_toggle_api_client.get_feature_toggle", return_value={})
     mocker.patch("app.user_api_client.check_verify_code", return_value=(True, ""))
     mocker.patch("app.service_api_client.get_services", return_value={"data": []})
     mocker.patch("app.service_api_client.update_service", return_value=service)
@@ -635,6 +636,7 @@ def validate_route_permission(
 
 def validate_route_permission_with_client(mocker, client, method, response_code, route, permissions, usr, service):
     usr["permissions"][str(service["id"])] = permissions
+    mocker.patch("app.feature_toggle_api_client.get_feature_toggle", return_value={})
     mocker.patch("app.user_api_client.check_verify_code", return_value=(True, ""))
     mocker.patch("app.service_api_client.get_services", return_value={"data": []})
     mocker.patch("app.service_api_client.update_service", return_value=service)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -29,6 +29,7 @@ class TestClient(FlaskClient):
             session["user_id"] = model_user.id
         if mocker:
             mocker.patch("app.user_api_client.get_user", return_value=user)
+            mocker.patch("app.feature_toggle_api_client.get_feature_toggle", return_value={})
         if mocker and service:
             with self.session_transaction() as session:
                 session["service_id"] = service["id"]

--- a/tests/app/main/test_errorhandlers.py
+++ b/tests/app/main/test_errorhandlers.py
@@ -1,5 +1,5 @@
 import pytest
-from flask import Response, url_for
+from flask import Response, g, url_for
 from flask_wtf.csrf import CSRFError
 from notifications_python_client.errors import HTTPError
 
@@ -16,6 +16,7 @@ def test_bad_url_returns_page_not_found(client_request):
 def test_load_service_before_request_handles_404(client_request, mocker):
     exc = HTTPError(Response(status=404), "Not found")
     get_service = mocker.patch("app.service_api_client.get_service", side_effect=exc)
+    g.service_status_text = ""
 
     client_request.get(
         "main.service_dashboard", service_id="00000000-0000-0000-0000-000000000000", _expected_status=404

--- a/tests/app/main/test_request_header.py
+++ b/tests/app/main/test_request_header.py
@@ -12,7 +12,9 @@ from tests.conftest import set_config_values
         (False, "key_1", 200),
     ],
 )
-def test_route_correct_secret_key(notify_admin, check_proxy_header, header_value, expected_code):
+def test_route_correct_secret_key(notify_admin, mocker, check_proxy_header, header_value, expected_code):
+    mocker.patch("app.feature_toggle_api_client.get_feature_toggle", return_value={})
+
     with set_config_values(
         notify_admin,
         {

--- a/tests/app/main/views/accounts/test_choose_accounts.py
+++ b/tests/app/main/views/accounts/test_choose_accounts.py
@@ -297,8 +297,6 @@ def test_should_not_show_back_to_service_if_user_doesnt_belong_to_service(
 ):
     mock_get_service.return_value = service_two
     expected_page_text = (
-        # Page has no ‘back to’ link
-        "You’re not allowed to see this page "
         "To check your permissions, speak to a member of your team who can manage settings, team and usage."
     )
     page = client_request.get(
@@ -309,9 +307,7 @@ def test_should_not_show_back_to_service_if_user_doesnt_belong_to_service(
         _test_page_title=False,
     )
 
-    assert normalize_spaces(page.select_one("header + .govuk-width-container").text).startswith(
-        normalize_spaces(expected_page_text)
-    )
+    assert normalize_spaces(page.select("p")[2].text).startswith(normalize_spaces(expected_page_text))
 
 
 def test_should_show_back_to_service_if_user_belongs_to_service(
@@ -322,7 +318,7 @@ def test_should_show_back_to_service_if_user_belongs_to_service(
     service_one,
 ):
     mock_get_service.return_value = service_one
-    expected_page_text = "Test Service   Switch service " "Dashboard Templates Uploads Team members"
+    expected_page_text = "Test Service Switch service"
 
     page = client_request.get(
         "main.view_template",
@@ -331,6 +327,6 @@ def test_should_show_back_to_service_if_user_belongs_to_service(
         _test_page_title=False,
     )
 
-    assert normalize_spaces(page.select_one("header + .govuk-width-container").text).startswith(
+    assert normalize_spaces(page.select_one(".navigation-service").text).startswith(
         normalize_spaces(expected_page_text)
     )

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -5032,7 +5032,7 @@ def test_send_files_by_email_contact_details_page(
 ):
     service_one["contact_link"] = contact_link
     page = client_request.get("main.send_files_by_email_contact_details", service_id=SERVICE_ONE_ID)
-    assert normalize_spaces(page.select("h2")[1].text) == subheader
+    assert normalize_spaces(page.select("h2")[2].text) == subheader
     if button_selected:
         assert "checked" in page.select_one("input[name=contact_details_type][value=email_address]").attrs
     else:

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -284,37 +284,6 @@ def test_organisation_name_links_to_org_dashboard(
 
 
 @pytest.mark.parametrize(
-    "service_contact_link,expected_text",
-    [
-        ("contact.me@gov.uk", "Send files by email contact.me@gov.uk Manage sending files by email"),
-        (None, "Send files by email Not set up Manage sending files by email"),
-    ],
-)
-def test_send_files_by_email_row_on_settings_page(
-    client_request,
-    platform_admin_user,
-    no_reply_to_email_addresses,
-    no_letter_contact_blocks,
-    single_sms_sender,
-    mock_get_service_settings_page_common,
-    mocker,
-    service_contact_link,
-    expected_text,
-):
-    service_one = service_json(
-        SERVICE_ONE_ID, permissions=["sms", "email"], organisation_id=ORGANISATION_ID, contact_link=service_contact_link
-    )
-
-    mocker.patch("app.service_api_client.get_service", return_value={"data": service_one})
-
-    client_request.login(platform_admin_user, service_one)
-    response = client_request.get("main.service_settings", service_id=SERVICE_ONE_ID)
-
-    org_row = find_element_by_tag_and_partial_text(response, tag="tr", string="Send files by email")
-    assert normalize_spaces(org_row.get_text()) == expected_text
-
-
-@pytest.mark.parametrize(
     "permissions, expected_rows",
     [
         (
@@ -5032,7 +5001,7 @@ def test_send_files_by_email_contact_details_page(
 ):
     service_one["contact_link"] = contact_link
     page = client_request.get("main.send_files_by_email_contact_details", service_id=SERVICE_ONE_ID)
-    assert normalize_spaces(page.select("h2")[2].text) == subheader
+    assert normalize_spaces(page.select("h2")[1].text) == subheader
     if button_selected:
         assert "checked" in page.select_one("input[name=contact_details_type][value=email_address]").attrs
     else:

--- a/tests/app/notify_client/test_feature_toggle_client.py
+++ b/tests/app/notify_client/test_feature_toggle_client.py
@@ -1,0 +1,9 @@
+from app.notify_client.feature_toggle_api_client import FeatureToggleApiClient
+
+
+def test_feature_toggle_client_calls_correct_api_endpoint(mocker):
+    client = FeatureToggleApiClient()
+    mock_get = mocker.patch.object(client, "get", return_value={})
+
+    client.get_feature_toggle(feature_toggle_name="foo")
+    mock_get.assert_called_once_with("/feature-toggle", params={"feature_toggle_name": "foo"})

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -572,9 +572,7 @@ def test_caseworkers_get_caseworking_navigation(
 ):
     client_request.login(active_caseworking_user)
     page = client_request.get("main.choose_template", service_id=SERVICE_ONE_ID)
-    assert normalize_spaces(page.select_one("header + .govuk-width-container nav").text) == (
-        "Templates Sent messages Uploads Team members"
-    )
+    assert normalize_spaces(page.select_one(".navigation").text) == ("Templates Sent messages Uploads Team members")
 
 
 def test_caseworkers_see_jobs_nav_if_jobs_exist(
@@ -587,6 +585,4 @@ def test_caseworkers_see_jobs_nav_if_jobs_exist(
 ):
     client_request.login(active_caseworking_user)
     page = client_request.get("main.choose_template", service_id=SERVICE_ONE_ID)
-    assert normalize_spaces(page.select_one("header + .govuk-width-container nav").text) == (
-        "Templates Sent messages Uploads Team members"
-    )
+    assert normalize_spaces(page.select_one(".navigation").text) == ("Templates Sent messages Uploads Team members")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2710,6 +2710,8 @@ def os_environ():
 
 @pytest.fixture  # noqa (C901 too complex)
 def client_request(_logged_in_client, mocker, service_one):  # noqa (C901 too complex)
+    mocker.patch("app.feature_toggle_api_client.get_feature_toggle", return_value={})
+
     def block_method(object, method_name, preferred_method_name):
         def blocked_method(*args, **kwargs):
             raise AttributeError(


### PR DESCRIPTION
See https://github.com/alphagov/emergency-alerts-api/pull/70.
This change retrieves the "service_is_not_live" feature toggle from the database, and uses it to inform the display of the informative not live banner in the header, which appears across every page.