### PR TITLE
Various A11y fixes

### DIFF
--- a/app/assets/stylesheets/components/banner.scss
+++ b/app/assets/stylesheets/components/banner.scss
@@ -138,11 +138,14 @@
     }
 
   }
+
   img {
     display: block;
     margin: 0 auto;
+    max-width: 100%;
+    max-height: 425px;
     width: auto;
-    height: 425px;
+    height: auto;
     position: relative;
     top: -1 * govuk-spacing(2);
   }

--- a/app/assets/stylesheets/govuk-frontend/overrides.scss
+++ b/app/assets/stylesheets/govuk-frontend/overrides.scss
@@ -17,6 +17,7 @@ $notify-secondary-button-hover-colour: govuk-shade(govuk-colour("light-grey"), 1
 
   &__logo {
     width: auto;
+    padding-right: 5px;
   }
 
   &__content {

--- a/app/templates/views/broadcast/partials/dashboard-table.html
+++ b/app/templates/views/broadcast/partials/dashboard-table.html
@@ -8,7 +8,7 @@
       <h2>
         <a class="file-list-filename-large govuk-link govuk-link--no-visited-state" href="{{ url_for(view_broadcast_endpoint, service_id=current_service.id, broadcast_message_id=item.id) }}">{{ item.template.name }}</a>
       </h2>
-      <span class="file-list-hint-large govuk-!-margin-bottom-2">
+      <span class="file-list-hint-large govuk-!-margin-bottom-2" tabindex="0">
         {{ item.content }}
       </span>
       {% if item.status == 'pending-approval' %}

--- a/app/templates/views/broadcast/tour/1.html
+++ b/app/templates/views/broadcast/tour/1.html
@@ -24,7 +24,7 @@
           imminent risk to life.
         </p>
         <p class="govuk-body heading-medium">
-          <a class="govuk-link" href='{{ url_for(".broadcast_tour", service_id=current_service.id, step_index=2) }}'>
+          <a class="govuk-link govuk-link--no-visited-state" href='{{ url_for(".broadcast_tour", service_id=current_service.id, step_index=2) }}'>
             Continue
           </a>
         </p>

--- a/app/templates/views/broadcast/tour/2.html
+++ b/app/templates/views/broadcast/tour/2.html
@@ -22,7 +22,7 @@
           tablet in the affected area.
         </p>
         <p class="govuk-body heading-medium govuk-!-margin-bottom-6">
-          <a class="govuk-link" href='{{ url_for(".broadcast_tour", service_id=current_service.id, step_index=3) }}'>
+          <a class="govuk-link govuk-link--no-visited-state" href='{{ url_for(".broadcast_tour", service_id=current_service.id, step_index=3) }}'>
             Continue
           </a>
         </p>

--- a/app/templates/views/broadcast/tour/3.html
+++ b/app/templates/views/broadcast/tour/3.html
@@ -21,7 +21,7 @@
           noise, even if it’s set on silent.
         </p>
         <p class="govuk-body heading-medium">
-          <a class="govuk-link" href='{{ url_for(".broadcast_tour", service_id=current_service.id, step_index=4) }}'>
+          <a class="govuk-link govuk-link--no-visited-state" href='{{ url_for(".broadcast_tour", service_id=current_service.id, step_index=4) }}'>
             Continue
           </a>
         </p>

--- a/app/templates/views/broadcast/tour/4.html
+++ b/app/templates/views/broadcast/tour/4.html
@@ -24,7 +24,7 @@
           know your phone number or location to send you an alert.
         </p>
         <p class="govuk-body heading-medium">
-          <a class="govuk-link" href='{{ url_for(".broadcast_tour", service_id=current_service.id, step_index=5) }}'>
+          <a class="govuk-link govuk-link--no-visited-state" href='{{ url_for(".broadcast_tour", service_id=current_service.id, step_index=5) }}'>
             Continue
           </a>
         </p>

--- a/app/templates/views/broadcast/tour/5.html
+++ b/app/templates/views/broadcast/tour/5.html
@@ -34,7 +34,7 @@
           When you’re ready, you can ask for access to the live system.
         </p>
         <p class="govuk-body heading-medium">
-          <a class="govuk-link" href='{{ url_for(".service_dashboard", service_id=current_service.id) }}'>
+          <a class="govuk-link govuk-link--no-visited-state" href='{{ url_for(".service_dashboard", service_id=current_service.id) }}'>
             Continue
           </a>
         </p>

--- a/app/templates/views/broadcast/tour/6.html
+++ b/app/templates/views/broadcast/tour/6.html
@@ -1,5 +1,5 @@
 {% from "components/banner.html" import banner_wrapper %}
-{% from "service_navigation.html" import service_navigation %}
+{% from "service_navigation.html" import navigation_service_name %}
 
 {% extends "admin_template.html" %}
 
@@ -11,32 +11,33 @@
 
 {% block content %}
 
-<div class="navigation-service">
-  {{ service_navigation(current_user, current_service) }}
-      <div class="banner-tour banner-tour-with-service-name">
-        <div class="govuk-grid-row">
-          <div class="govuk-grid-column-one-half">
-            <h1 class="heading-large">
-              What happens in live mode
-            </h1>
-            <p class="govuk-body heading-medium">
-              Emergency Alerts has not sent your alert because you’re in training mode.
-            </p>
-            <p class="govuk-body heading-medium">
-              In a real emergency, every compatible mobile phone and tablet in the area
-              you chose would make a loud alarm noise.
-            </p>
-            <p class="govuk-body heading-medium">
-              <a class="govuk-link govuk-link--no-visited-state" href='{{ url_for(".service_dashboard", service_id=current_service.id) }}'>
-                Continue
-              </a>
-            </p>
-          </div>
-          <div class="govuk-grid-column-one-half govuk-!-padding-top-6">
-            <img src="{{ asset_url('images/broadcast-tour/3.png') }}" alt="">
-          </div>
-        </div>
+  <div class="navigation-service">
+    {{ navigation_service_name(current_service) }}
+  </div>
+
+  <div class="banner-tour banner-tour-with-service-name">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-half">
+        <h1 class="heading-large">
+          What happens in live mode
+        </h1>
+        <p class="govuk-body heading-medium">
+          Emergency Alerts has not sent your alert because you’re in training mode.
+        </p>
+        <p class="govuk-body heading-medium">
+          In a real emergency, every compatible mobile phone and tablet in the area
+          you chose would make a loud alarm noise.
+        </p>
+        <p class="govuk-body heading-medium">
+          <a class="govuk-link govuk-link--no-visited-state" href='{{ url_for(".service_dashboard", service_id=current_service.id) }}'>
+            Continue
+          </a>
+        </p>
       </div>
+      <div class="govuk-grid-column-one-half govuk-!-padding-top-6">
+        <img src="{{ asset_url('images/broadcast-tour/3.png') }}" alt="">
+      </div>
+    </div>
   </div>
 
 {% endblock %}

--- a/app/templates/views/broadcast/write-new-broadcast.html
+++ b/app/templates/views/broadcast/write-new-broadcast.html
@@ -7,7 +7,7 @@
 {% from "components/error-summary.html" import errorSummary %}
 
 {% block service_page_title %}
-  New alert
+  New alert message
 {% endblock %}
 
 
@@ -19,7 +19,7 @@
 
   {{ errorSummary(form) }}
 
-  {{ page_header('New alert')}}
+  {{ page_header('New alert message')}}
 
   {% call form_wrapper() %}
     <div class="govuk-grid-row">

--- a/app/templates/views/user-profile.html
+++ b/app/templates/views/user-profile.html
@@ -1,5 +1,5 @@
 {% extends "withoutnav_template.html" %}
-{% from "govuk_frontend_jinja/components/summary-list/macro.html" import govukSummaryList %}
+{% from "govuk_frontend_jinja/components/table/macro.html" import govukTable %}
 
 {% block per_page_title %}
   Your profile
@@ -11,154 +11,121 @@
 
   {% if can_see_edit %}
     {% set email_address_row =
-      {
-        "key": {
-          "classes": "notify-summary-list__key notify-summary-list__key--one-quarter",
+      [
+        {
           "text": "Email address"
         },
-        "value": {
+        {
           "text": current_user.email_address
         },
-        "actions": {
-          "items": [{
-            "href": url_for('.user_profile_email'),
-            "text": "Change",
-            "visuallyHiddenText": "email address",
-            "classes": "govuk-link--no-visited-state"
-          }]
+        {
+          "html": change_link('.user_profile_email', 'email address')
         }
-      }
+      ]
     %}
   {% else %}
     {% set email_address_row =
-      {
-        "classes": "govuk-summary-list__row--no-actions",
-        "key": {
-          "classes": "notify-summary-list__key notify-summary-list__key--one-quarter",
+      [
+        {
           "text": "Email address"
         },
-        "value": {
+        {
           "text": current_user.email_address
-        },
-      }
+        }
+      ]
     %}
   {% endif %}
 
   {% set rows = [
-    {
-      "key": {
-        "classes": "notify-summary-list__key notify-summary-list__key--one-quarter",
+    [
+      {
         "text": "Name"
       },
-      "value": {
+      {
         "text": current_user.name
       },
-      "actions": {
-        "items": [
-          {
-            "href": url_for('.user_profile_name'),
-            "text": "Change",
-            "visuallyHiddenText": "name",
-            "classes": "govuk-link--no-visited-state"
-          }
-        ]
+      {
+        "html": change_link('.user_profile_name', 'name')
       }
-    },
+    ],
     email_address_row,
-    {
-      "key": {
-        "classes": "notify-summary-list__key notify-summary-list__key--one-quarter",
+    [
+      {
         "text": "Mobile number"
       },
-      "value": {
+      {
         "text": current_user.mobile_number or "Not set",
-        "classes": "" if current_user.mobile_number else "table-field-status-default"
       },
-      "actions": {
-        "items": [
-        {
-          "href": url_for('.user_profile_mobile_number'),
-          "text": "Change",
-          "visuallyHiddenText": "mobile number",
-          "classes": "govuk-link--no-visited-state"
-        }
-
-        ]
+      {
+        "html": change_link('.user_profile_mobile_number', 'mobile number')
       }
-    },
-    {
-      "key": {
-        "classes": "notify-summary-list__key notify-summary-list__key--one-quarter",
+    ],
+    [
+      {
         "text": "Password"
       },
-      "value": {
-        "text": ('Last changed ' + current_user.password_changed_at|format_delta)
+      {
+        "text": 'Last changed ' + current_user.password_changed_at|format_delta
       },
-      "actions": {
-        "items": [
-          {
-            "href": url_for('.user_profile_password'),
-            "text": "Change",
-            "visuallyHiddenText": "password",
-            "classes": "govuk-link--no-visited-state"
-          }
-        ]
+      {
+        "html": change_link('.user_profile_password', 'password')
       }
-    }
+    ]
   ]%}
 
  {% if current_user.can_use_webauthn %}
   {% set _ = rows.append(
-    {
-      "key": {
-        "classes": "notify-summary-list__key notify-summary-list__key--one-quarter",
+    [
+      {
         "text": "Security keys"
       },
-      "value": {
+      {
         "text": ('{} registered'.format(current_user.webauthn_credentials|length)) if current_user.webauthn_credentials else "None registered",
-        "classes": "" if current_user.webauthn_credentials else "table-field-status-default"
       },
-      "actions": {
-        "items": [
-          {
-            "href": url_for('.user_profile_security_keys'),
-            "text": "Change",
-            "visuallyHiddenText": "security keys",
-            "classes": "govuk-link--no-visited-state"
-          }
-        ]
+      {
+        "html": change_link('.user_profile_security_keys', 'security keys')
       }
-    }
+    ]
   ) %}
  {% endif %}
 
  {% if current_user.platform_admin or session.get('disable_platform_admin_view') %}
   {% set _ = rows.append(
-    {
-      "key": {
-        "classes": "notify-summary-list__key notify-summary-list__key--one-quarter",
+    [
+      {
         "text": "Use platform admin view"
       },
-      "value": {
+      {
         "text": (not session.get('disable_platform_admin_view'))|format_yes_no
       },
-      "actions": {
-        "items": [
-          {
-            "href": url_for('.user_profile_disable_platform_admin_view'),
-            "text": "Change",
-            "visuallyHiddenText": "whether to use platform admin view",
-            "classes": "govuk-link--no-visited-state"
-          }
-        ]
+      {
+        "html": change_link('.user_profile_disable_platform_admin_view', 'whether to use platform admin view')
       }
-    },
+    ]
   ) %}
 {% endif %}
 
-{{ govukSummaryList({
-  "classes": "notify-summary-list",
+{{ govukTable({
+  "firstCellIsHeader": true,
+  "head": [
+    {
+      "text": "Personal details"
+    },
+    {
+      "text": "Detail values"
+    },
+    {
+      "text": "Change details"
+    }
+  ],
   "rows": rows
 }) }}
 
 {% endblock %}
+
+{% macro change_link(url, visually_hidden_text) %}
+  <a href="{{ url_for(url) }}" class="govuk-link--no-visited-state">
+    Change
+    <span class="govuk-visually-hidden"> {{ visually_hidden_text }}</span>
+  </a>
+{% endmacro %}

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -737,7 +737,7 @@ def test_write_new_broadcast_page(
         service_id=SERVICE_ONE_ID,
     )
 
-    assert normalize_spaces(page.select_one("h1").text) == "New alert"
+    assert normalize_spaces(page.select_one("h1").text) == "New alert message"
 
     form = page.select_one("form")
     assert form["method"] == "post"

--- a/tests/app/main/views/test_user_profile.py
+++ b/tests/app/main/views/test_user_profile.py
@@ -31,7 +31,7 @@ def test_overview_page_shows_disable_for_platform_admin(client_request, platform
     client_request.login(platform_admin_user)
     page = client_request.get("main.user_profile")
     assert page.select_one("h1").text.strip() == "Your profile"
-    disable_platform_admin_row = page.select(".govuk-summary-list__row")[-1]
+    disable_platform_admin_row = page.select(".govuk-table__row")[-1]
     assert (
         " ".join(disable_platform_admin_row.text.split())
         == "Use platform admin view Yes Change whether to use platform admin view"
@@ -61,7 +61,7 @@ def test_overview_page_shows_security_keys_if_user_they_can_use_webauthn(
         return_value=credentials,
     )
     page = client_request.get("main.user_profile")
-    security_keys_row = page.select(".govuk-summary-list__row")[-2]
+    security_keys_row = page.select(".govuk-table__row")[-2]
     assert " ".join(security_keys_row.text.split()) == expected_row_text
 
 


### PR DESCRIPTION
This PR covers a number of tickets raised with regards to accessibility, including:
- EAS-187: Multiple pages have h1 of "New alert", which is confusing for screen reader users
- EAS-253: User profile table can be ambiguous for screen reader users due to lack of a `<thead>`
- EAS-1074: Images in broadcast tour page 3 do not adapt to screen size
- EAS-1075: Unexpected space in broadcast tour page 6, between content and footer (inconsistent with other pages)
- EAS-1076: 'Continue' button in broadcast tour pages needs to use `govuk-link--no-visited-state`, for colour accessibility
- EAS-1096: 'New alert' description text area is not picked up by screen readers (needs tab index)
- Additionally, a fix for the header display, where, due to the inclusion of "Emergency Alerts" in the header, links when logged in as a Platform Admin would overlap in the header (if the screen size was between ~768px and ~778px - i.e., the point at which the media query comes in, and the point at which the areas overlap)