### PR TITLE
Eas 1342 security key registration content fix

### DIFF
--- a/app/main/views/webauthn_credentials.py
+++ b/app/main/views/webauthn_credentials.py
@@ -53,7 +53,7 @@ def webauthn_complete_register():
     current_user.update(auth_type="webauthn_auth")
 
     flash(
-        "Registration complete. Next time you sign in to Notify you’ll be asked to use your security key.",
+        "Registration complete. Next time you sign in to Emergency Alerts you’ll be asked to use your security key.",
         "default_with_tick",
     )
 

--- a/app/templates/views/two-factor-webauthn.html
+++ b/app/templates/views/two-factor-webauthn.html
@@ -55,7 +55,7 @@
 
       {{ govukErrorMessage({
         "classes": "webauthn__api-missing",
-        "text": "Your browser does not support security keys. Try signing in to Notify using a different browser."
+        "text": "Your browser does not support security keys. Try signing in to Emergency Alerts using a different browser."
       }) }}
 
       {{ govukErrorMessage({

--- a/app/templates/views/user-profile/security-keys.html
+++ b/app/templates/views/user-profile/security-keys.html
@@ -2,9 +2,9 @@
 {% from "components/page-header.html" import page_header %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
-{% from "components/table.html" import edit_field, mapping_table, row, field, row_heading %}
+{% from "components/table.html" import edit_field, mapping_table, row, field %}
 {% from "components/webauthn-api-check.html" import webauthn_api_check %}
-{% from "govuk_frontend_jinja/components/error-message/macro.html" import govukErrorMessage %}
+{% from "govuk_frontend_jinja/components/error-summary/macro.html" import govukErrorSummary %}
 
 {% set page_title = 'Security keys' %}
 {% set credentials = current_user.webauthn_credentials %}
@@ -18,7 +18,7 @@
 {% endblock %}
 
 {% block backLink %}
-  {{ govukBackLink({ "href": url_for('.user_profile') }) }}
+  {{ govukBackLink({ "href": url_for('main.user_profile') }) }}
 {% endblock %}
 
 {% block maincolumn_content %}
@@ -33,39 +33,44 @@
       "data-csrf-token": csrf_token(),
     }
   }) }}
-
-  {{ govukErrorMessage({
-    "classes": "webauthn__api-missing",
-    "text": "Your browser does not support security keys. Try signing in to Notify using a different browser."
-  }) }}
-
-  {{ govukErrorMessage({
-    "classes": "webauthn__no-js",
-    "text": "JavaScript is not available for this page. Security keys need JavaScript to work."
-  }) }}
 {% endset %}
 
-  {% set html %}
-    There’s a problem with your security key
-    <p class="govuk-body">
-      Check you have the right key and try again.
-      If this does not work,
-      <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.support') }}">contact us</a>.
-    </p>
-  {% endset %}
-  {{ govukErrorMessage({
-    "classes": "banner-dangerous govuk-!-display-none",
-    "html": html,
-    "attributes": {
-      "aria-live": "polite",
-      "tabindex": '-1'
-    }
+{% set errorSummaries %}
+
+  {{ govukErrorSummary({
+    "classes": "webauthn__api-missing",
+    "titleText": "There’s a problem",
+    "errorList": [{"text": "Your browser does not support security keys. Try signing in to Emergency Alerts using a different browser."}]
   }) }}
+
+  {% set keyProblemDescription %}
+    <p class="govuk-body">JavaScript is not available for this page. Security keys need JavaScript to work.</p>
+  {% endset %}
+
+  {{ govukErrorSummary({
+    "classes": "webauthn__no-js",
+    "titleText": "There’s a problem",
+    "errorList": [{"text": "JavaScript is not available for this page. Security keys need JavaScript to work."}]
+  }) }}
+
+  {% set keyProblemDescription %}
+    Check you have the right key and try again. If this does not work,
+     <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.support') }}">contact us</a>.
+  {% endset %}
+
+  {{ govukErrorSummary({
+    "classes": "govuk-!-display-none",
+    "attributes": { "aria-live": "polite", "tabindex":"-1" },
+    "titleText": "There’s a problem with your security keys",
+    "errorList": [{"html": keyProblemDescription}]
+  }) }}
+{% endset %}
 
   <div class="govuk-grid-row">
 
     {% if credentials %}
       <div class="govuk-grid-column-five-sixths">
+        {{ errorSummaries }}
         {{ page_header(page_title) }}
         <div class="body-copy-table">
           {% call mapping_table(
@@ -86,7 +91,7 @@
                     {% endif %}
                   </div>
                 {% endcall %}
-                {{ edit_field('Manage', url_for('.user_profile_manage_security_key', key_id=credential.id)) }}
+                {{ edit_field('Manage', url_for('main.user_profile_manage_security_key', key_id=credential.id)) }}
               {% endcall %}
             {% endfor %}
           {% endcall %}
@@ -97,7 +102,7 @@
       <div class="govuk-grid-column-one-half">
         {{ page_header(page_title) }}
         <p class="govuk-body">
-          Security keys are an alternative way of signing in to Notify,
+          Security keys are an alternative way of signing in to Emergency Alerts,
           instead of getting a code in a text message
         </p>
         <p class="govuk-body">
@@ -109,7 +114,6 @@
       <div class="govuk-grid-column-one-quarter">
         <img src="{{ asset_url('images/security-key.svg') }}" alt="" class="webauthn-illustration" width="149" height="150">
       </div>
-      {% endif %}
-    </div>
+    {% endif %}
   </div>
 {% endblock %}

--- a/app/templates/views/user-profile/security-keys.html
+++ b/app/templates/views/user-profile/security-keys.html
@@ -4,7 +4,7 @@
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "components/table.html" import edit_field, mapping_table, row, field %}
 {% from "components/webauthn-api-check.html" import webauthn_api_check %}
-{% from "govuk_frontend_jinja/components/error-summary/macro.html" import govukErrorSummary %}
+{% from "govuk_frontend_jinja/components/error-message/macro.html" import govukErrorMessage %}
 
 {% set page_title = 'Security keys' %}
 {% set credentials = current_user.webauthn_credentials %}
@@ -18,7 +18,7 @@
 {% endblock %}
 
 {% block backLink %}
-  {{ govukBackLink({ "href": url_for('main.user_profile') }) }}
+  {{ govukBackLink({ "href": url_for('.user_profile') }) }}
 {% endblock %}
 
 {% block maincolumn_content %}
@@ -37,20 +37,24 @@
 
 {% set errorSummaries %}
 
-  {{ govukErrorSummary({
+  {% set keyProblemDescription %}
+    <p class="govuk-body">Your browser does not support security keys. Try signing in to Emergency Alerts using a different browser.</p>
+  {% endset %}
+
+  {{ govukErrorMessage({
     "classes": "webauthn__api-missing",
     "titleText": "There’s a problem",
-    "errorList": [{"text": "Your browser does not support security keys. Try signing in to Emergency Alerts using a different browser."}]
+    "descriptionHtml": keyProblemDescription
   }) }}
 
   {% set keyProblemDescription %}
     <p class="govuk-body">JavaScript is not available for this page. Security keys need JavaScript to work.</p>
   {% endset %}
 
-  {{ govukErrorSummary({
+  {{ govukErrorMessage({
     "classes": "webauthn__no-js",
     "titleText": "There’s a problem",
-    "errorList": [{"text": "JavaScript is not available for this page. Security keys need JavaScript to work."}]
+    "descriptionHtml": keyProblemDescription
   }) }}
 
   {% set keyProblemDescription %}
@@ -58,11 +62,11 @@
      <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.support') }}">contact us</a>.
   {% endset %}
 
-  {{ govukErrorSummary({
+  {{ govukErrorMessage({
     "classes": "govuk-!-display-none",
     "attributes": { "aria-live": "polite", "tabindex":"-1" },
     "titleText": "There’s a problem with your security keys",
-    "errorList": [{"html": keyProblemDescription}]
+    "descriptionHtml": keyProblemDescription
   }) }}
 {% endset %}
 
@@ -103,7 +107,7 @@
         {{ page_header(page_title) }}
         <p class="govuk-body">
           Security keys are an alternative way of signing in to Emergency Alerts,
-          instead of getting a code in a text message
+          instead of getting a code in a text message.
         </p>
         <p class="govuk-body">
           You can buy any key that’s compatible with the WebAuthn

--- a/app/templates/views/user-profile/security-keys.html
+++ b/app/templates/views/user-profile/security-keys.html
@@ -4,7 +4,7 @@
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "components/table.html" import edit_field, mapping_table, row, field %}
 {% from "components/webauthn-api-check.html" import webauthn_api_check %}
-{% from "govuk_frontend_jinja/components/error-message/macro.html" import govukErrorMessage %}
+{% from "govuk_frontend_jinja/components/error-summary/macro.html" import govukErrorSummary %}
 
 {% set page_title = 'Security keys' %}
 {% set credentials = current_user.webauthn_credentials %}
@@ -37,24 +37,16 @@
 
 {% set errorSummaries %}
 
-  {% set keyProblemDescription %}
-    <p class="govuk-body">Your browser does not support security keys. Try signing in to Emergency Alerts using a different browser.</p>
-  {% endset %}
-
-  {{ govukErrorMessage({
+  {{ govukErrorSummary({
     "classes": "webauthn__api-missing",
     "titleText": "There’s a problem",
-    "descriptionHtml": keyProblemDescription
+    "errorList": [{"text": "Your browser does not support security keys. Try signing in to Emergency Alerts using a different browser."}]
   }) }}
 
-  {% set keyProblemDescription %}
-    <p class="govuk-body">JavaScript is not available for this page. Security keys need JavaScript to work.</p>
-  {% endset %}
-
-  {{ govukErrorMessage({
+  {{ govukErrorSummary({
     "classes": "webauthn__no-js",
     "titleText": "There’s a problem",
-    "descriptionHtml": keyProblemDescription
+    "errorList": [{"text": "JavaScript is not available for this page. Security keys need JavaScript to work."}]
   }) }}
 
   {% set keyProblemDescription %}
@@ -62,11 +54,11 @@
      <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.support') }}">contact us</a>.
   {% endset %}
 
-  {{ govukErrorMessage({
+  {{ govukErrorSummary({
     "classes": "govuk-!-display-none",
     "attributes": { "aria-live": "polite", "tabindex":"-1" },
     "titleText": "There’s a problem with your security keys",
-    "descriptionHtml": keyProblemDescription
+    "errorList": [{"html": keyProblemDescription}]
   }) }}
 {% endset %}
 

--- a/tests/app/main/views/test_webauthn_credentials.py
+++ b/tests/app/main/views/test_webauthn_credentials.py
@@ -170,7 +170,8 @@ def test_complete_register_clears_session(
         assert session["_flashes"] == [
             (
                 "default_with_tick",
-                "Registration complete. Next time you sign in to Notify you’ll be asked to use your security key.",
+                "Registration complete. Next time you sign in to Emergency Alerts "
+                "you’ll be asked to use your security key.",
             )
         ]
 


### PR DESCRIPTION
Replacing instances of "Notify" with "Emergency Alerts" for the security key flow, plus fix of the error message appearing on screen even when there was a success by splitting out errors into conditional error summary components.