### PR TITLE
Allow no alert duration specified; use old defaults

### DIFF
--- a/app/models/broadcast_message.py
+++ b/app/models/broadcast_message.py
@@ -309,7 +309,13 @@ class BroadcastMessage(JSONModel):
         self._set_status_to("pending-approval")
 
     def approve_broadcast(self, channel):
-        ttl = timedelta(seconds=self.duration)
+        if self.duration == 0 or self.duration is None:
+            if channel in {"test", "operator"}:
+                ttl = timedelta(hours=4, minutes=0)
+            else:
+                ttl = timedelta(hours=22, minutes=30)
+        else:
+            ttl = timedelta(seconds=self.duration)
 
         self._update(
             starts_at=datetime.utcnow().isoformat(),

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -2725,7 +2725,7 @@ def test_user_without_approve_permission_cant_approve_broadcast_they_created(
         ("test", 10800, "2020-02-23T01:22:22"),  # 3 hours later
         ("severe", 21600, "2020-02-23T04:22:22"),  # 6 hours later
         ("government", 79200, "2020-02-23T20:22:22"),  # 22 hours later
-        (None, 0, "2020-02-22T22:22:22"),  # Training mode
+        (None, 0, "2020-02-23T20:52:22"),  # Training mode
     ),
 )
 @pytest.mark.parametrize(
@@ -2825,7 +2825,7 @@ def test_confirm_approve_broadcast(
             template_id=fake_uuid,
             created_by_id=fake_uuid,
             duration=duration,
-            finishes_at="2020-02-22T22:52:22.000000",
+            finishes_at="2020-02-23T20:52:22.000000",
             status=initial_status,
         ),
     )


### PR DESCRIPTION
This PR makes it such that no alert duration can be specified; therefore allowing any cases where it hasn't been specified and is 0 (or None, for whatever reason) is handled appropriately by just using the old approach of checking which channel the alert will be sent over. One use case for this would be when alerts are created directly via the API.