### PR TITLE
Revert "Comment out alert duration feature and change links accordingly (#90)"

### DIFF
--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -6,6 +6,7 @@ from app.main.forms import (
     BroadcastAreaForm,
     BroadcastAreaFormWithSelectAll,
     BroadcastTemplateForm,
+    ChooseDurationForm,
     ConfirmBroadcastForm,
     NewBroadcastForm,
     SearchByNameForm,
@@ -195,34 +196,34 @@ def broadcast(service_id, template_id):
     )
 
 
-# @main.route("/services/<uuid:service_id>/broadcast/<uuid:broadcast_message_id>/duration", methods=["GET", "POST"])
-# @user_has_permissions("create_broadcasts", restrict_admin_usage=True)
-# @service_has_permission("broadcast")
-# def choose_broadcast_duration(service_id, broadcast_message_id):
-#     form = ChooseDurationForm()
+@main.route("/services/<uuid:service_id>/broadcast/<uuid:broadcast_message_id>/duration", methods=["GET", "POST"])
+@user_has_permissions("create_broadcasts", restrict_admin_usage=True)
+@service_has_permission("broadcast")
+def choose_broadcast_duration(service_id, broadcast_message_id):
+    form = ChooseDurationForm()
 
-#     broadcast_message = BroadcastMessage.from_id(
-#         broadcast_message_id,
-#         service_id=current_service.id,
-#     )
+    broadcast_message = BroadcastMessage.from_id(
+        broadcast_message_id,
+        service_id=current_service.id,
+    )
 
-#     back_link = url_for(
-#         ".preview_broadcast_areas", service_id=current_service.id, broadcast_message_id=broadcast_message_id
-#     )
+    back_link = url_for(
+        ".preview_broadcast_areas", service_id=current_service.id, broadcast_message_id=broadcast_message_id
+    )
 
-#     if form.validate_on_submit():
-#         BroadcastMessage.update_duration(
-#             service_id=current_service.id,
-#             broadcast_message_id=broadcast_message_id,
-#             duration=form.content.data,
-#         )
-#         return redirect(
-#             url_for(
-#                 ".preview_broadcast_message", service_id=current_service.id, broadcast_message_id=broadcast_message.id
-#             )
-#         )
+    if form.validate_on_submit():
+        BroadcastMessage.update_duration(
+            service_id=current_service.id,
+            broadcast_message_id=broadcast_message_id,
+            duration=form.content.data,
+        )
+        return redirect(
+            url_for(
+                ".preview_broadcast_message", service_id=current_service.id, broadcast_message_id=broadcast_message.id
+            )
+        )
 
-#     return render_template("views/broadcast/duration.html", form=form, back_link=back_link)
+    return render_template("views/broadcast/duration.html", form=form, back_link=back_link)
 
 
 @main.route("/services/<uuid:service_id>/broadcast/<uuid:broadcast_message_id>/areas")

--- a/app/navigation.py
+++ b/app/navigation.py
@@ -144,7 +144,7 @@ class MainNavigation(Navigation):
             "view_current_broadcast",
             "new_broadcast",
             "write_new_broadcast",
-            # "choose_broadcast_duration",
+            "choose_broadcast_duration",
         },
         "previous-broadcasts": {
             "broadcast_dashboard_previous",

--- a/app/templates/views/broadcast/partials/dashboard-table.html
+++ b/app/templates/views/broadcast/partials/dashboard-table.html
@@ -39,9 +39,9 @@
             <li class="area-list-item area-list-item--unremoveable area-list-item--smaller">{{ area.name }}</li>
           {% endfor %}
         </ul>
-        <!-- {% if item.duration|format_seconds_duration_as_time != "0 seconds" %}
+        {% if item.duration|format_seconds_duration_as_time != "0 seconds" %}
           <p class="govuk-!-margin-right-2 duration-preview">Duration: {{ item.duration|format_seconds_duration_as_time }}</p>
-        {% endif %} -->
+        {% endif %}
       </div>
     </div>
   </div>

--- a/app/templates/views/broadcast/preview-areas.html
+++ b/app/templates/views/broadcast/preview-areas.html
@@ -55,8 +55,8 @@
     {{ map(broadcast_message) }}
     {{ govukButton({
       "element": "a",
-      "text": "Preview this alert",
-      "href": url_for('.preview_broadcast_message', service_id=current_service.id, broadcast_message_id=broadcast_message.id),
+      "text": "Continue",
+      "href": url_for('.choose_broadcast_duration', service_id=current_service.id, broadcast_message_id=broadcast_message.id),
       "classes": "govuk-button"
     }) }}
 

--- a/app/templates/views/broadcast/preview-message.html
+++ b/app/templates/views/broadcast/preview-message.html
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block backLink %}
-  {{ govukBackLink({ "href": url_for('.preview_broadcast_areas', service_id=current_service.id, broadcast_message_id=broadcast_message.id) }) }}
+  {{ govukBackLink({ "href": url_for('.choose_broadcast_duration', service_id=current_service.id, broadcast_message_id=broadcast_message.id) }) }}
 {% endblock %}
 
 {% block maincolumn_content %}
@@ -29,7 +29,7 @@
         </li>
       {% endfor %}
     </ul>
-    <!-- <p class="govuk-!-margin-right-2 duration-preview">Duration: {{ broadcast_message.duration|format_seconds_duration_as_time }}</p> -->
+    <p class="govuk-!-margin-right-2 duration-preview">Duration: {{ broadcast_message.duration|format_seconds_duration_as_time }}</p>
   </div>
 
   {% call form_wrapper() %}

--- a/app/templates/views/broadcast/view-message.html
+++ b/app/templates/views/broadcast/view-message.html
@@ -191,9 +191,9 @@
           </li>
         {% endfor %}
       </ul>
-      <!-- {% if broadcast_message.duration|format_seconds_duration_as_time != "0 seconds" %}
+      {% if broadcast_message.duration|format_seconds_duration_as_time != "0 seconds" %}
         <p class="govuk-!-margin-right-2 duration-preview">Duration: {{ broadcast_message.duration|format_seconds_duration_as_time }}</p>
-      {% endif %} -->
+      {% endif %}
     </div>
   {% endif %}
 

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -85,12 +85,12 @@ sample_uuid = sample_uuid()
             403,
             405,
         ),
-        # (
-        #     ".choose_broadcast_duration",
-        #     {"broadcast_message_id": sample_uuid},
-        #     403,
-        #     403,
-        # ),
+        (
+            ".choose_broadcast_duration",
+            {"broadcast_message_id": sample_uuid},
+            403,
+            403,
+        ),
         (
             ".preview_broadcast_message",
             {"broadcast_message_id": sample_uuid},
@@ -1833,60 +1833,60 @@ def test_remove_broadcast_area_page(
     )
 
 
-# def test_choose_broadcast_duration_page(
-#     client_request,
-#     service_one,
-#     active_user_create_broadcasts_permission,
-#     mock_get_draft_broadcast_message,
-#     fake_uuid,
-# ):
-#     service_one["permissions"] += ["broadcast"]
-#     client_request.login(active_user_create_broadcasts_permission)
-#     page = client_request.get(
-#         ".choose_broadcast_duration",
-#         service_id=SERVICE_ONE_ID,
-#         broadcast_message_id=fake_uuid,
-#     )
+def test_choose_broadcast_duration_page(
+    client_request,
+    service_one,
+    active_user_create_broadcasts_permission,
+    mock_get_draft_broadcast_message,
+    fake_uuid,
+):
+    service_one["permissions"] += ["broadcast"]
+    client_request.login(active_user_create_broadcasts_permission)
+    page = client_request.get(
+        ".choose_broadcast_duration",
+        service_id=SERVICE_ONE_ID,
+        broadcast_message_id=fake_uuid,
+    )
 
-#     assert normalize_spaces(page.select_one("h1").text) == "Choose alert duration"
+    assert normalize_spaces(page.select_one("h1").text) == "Choose alert duration"
 
-#     form = page.select_one("form")
-#     assert form["method"] == "post"
-#     assert "action" not in form
+    form = page.select_one("form")
+    assert form["method"] == "post"
+    assert "action" not in form
 
-#     assert [
-#         (
-#             choice.select_one("input")["name"],
-#             choice.select_one("input")["value"],
-#             normalize_spaces(choice.select_one("label").text),
-#         )
-#         for choice in form.select(".govuk-radios__item")
-#     ] == [
-#         ("content", "PT30M", "30 minutes"),
-#         ("content", "PT3H", "3 hours"),
-#         ("content", "PT6H", "6 hours"),
-#         ("content", "PT22H", "22 hours"),
-#     ]
+    assert [
+        (
+            choice.select_one("input")["name"],
+            choice.select_one("input")["value"],
+            normalize_spaces(choice.select_one("label").text),
+        )
+        for choice in form.select(".govuk-radios__item")
+    ] == [
+        ("content", "PT30M", "30 minutes"),
+        ("content", "PT3H", "3 hours"),
+        ("content", "PT6H", "6 hours"),
+        ("content", "PT22H", "22 hours"),
+    ]
 
 
-# def test_choose_broadcast_duration(
-#     client_request,
-#     service_one,
-#     mock_get_draft_broadcast_message,
-#     mock_update_broadcast_message,
-#     fake_uuid,
-#     active_user_create_broadcasts_permission,
-# ):
-#     service_one["permissions"] += ["broadcast"]
+def test_choose_broadcast_duration(
+    client_request,
+    service_one,
+    mock_get_draft_broadcast_message,
+    mock_update_broadcast_message,
+    fake_uuid,
+    active_user_create_broadcasts_permission,
+):
+    service_one["permissions"] += ["broadcast"]
 
-#     client_request.login(active_user_create_broadcasts_permission)
-#     client_request.post(
-#         ".choose_broadcast_duration",
-#         service_id=SERVICE_ONE_ID,
-#         broadcast_message_id=fake_uuid,
-#         _data={"duration": "PT30M"},
-#         _expected_status=200,
-#     )
+    client_request.login(active_user_create_broadcasts_permission)
+    client_request.post(
+        ".choose_broadcast_duration",
+        service_id=SERVICE_ONE_ID,
+        broadcast_message_id=fake_uuid,
+        _data={"duration": "PT30M"},
+        _expected_status=200,
+    )
 
 
 def test_preview_broadcast_message_page(
@@ -1909,7 +1909,7 @@ def test_preview_broadcast_message_page(
         "Scotland",
     ]
 
-    # assert page.select_one("p.duration-preview").text == "Duration: 0 seconds"
+    assert page.select_one("p.duration-preview").text == "Duration: 0 seconds"
 
     assert normalize_spaces(page.select_one("h2.broadcast-message-heading").text) == "Emergency alert"
 

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -62,7 +62,7 @@ EXCLUDED_ENDPOINTS = tuple(
             "check_tour_notification",
             "choose_account",
             "choose_broadcast_area",
-            # "choose_broadcast_duration",
+            "choose_broadcast_duration",
             "choose_broadcast_library",
             "choose_broadcast_sub_area",
             "choose_from_contact_list",


### PR DESCRIPTION
This reverts commit 0913a89b9eb4008feb0040d48a229bf1c2b1a8cf, due to a need to demo this functionality before we remove it from the service.