### PR TITLE
Eas 1260 - a11y issues oct 23

### DIFF
--- a/app/assets/stylesheets/_app.scss
+++ b/app/assets/stylesheets/_app.scss
@@ -221,3 +221,8 @@ details .arrow {
   display: inline-block;
 
 }
+
+.broadcast-message-wrapper a {
+  font-weight: 600;
+  font-size: 18.5px !important;
+}

--- a/app/assets/stylesheets/_app.scss
+++ b/app/assets/stylesheets/_app.scss
@@ -224,5 +224,5 @@ details .arrow {
 
 .broadcast-message-wrapper a {
   font-weight: 600;
-  font-size: 18.5px !important;
+  font-size: 18.5px;
 }

--- a/app/assets/stylesheets/components/navigation.scss
+++ b/app/assets/stylesheets/components/navigation.scss
@@ -73,25 +73,24 @@
     border-bottom: 1px solid $govuk-border-colour;
     margin: 0 0 10px;
     position: relative;
+    display: flex;
+    flex-wrap: wrap;
 
     &-name {
 
-      padding: $padding-top 0 $padding-bottom 0;
-      max-width: 50%;
+      padding: $padding-top govuk-spacing(2) $padding-bottom 0;
+      flex-grow: 1;
 
     }
 
     &-switch {
 
       text-align: right;
-      position: absolute;
       top: 0;
       right: 0;
-      padding: $padding-top 0 $padding-bottom govuk-spacing(3);
-
-      &:focus {
-        padding: $padding-top 0px $padding-bottom + 1px govuk-spacing(3) + 10;
-      }
+      padding: $padding-top 0 $padding-bottom 0;
+      min-width: 0;
+      flex-shrink: 2;
 
     }
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1198,10 +1198,10 @@ class ConfirmBroadcastForm(StripWhitespaceForm):
 
 
 class BaseTemplateForm(StripWhitespaceForm):
-    name = GovukTextInputField("Template name", validators=[DataRequired(message="Cannot be empty")])
+    name = GovukTextInputField("Template name", validators=[DataRequired(message="Template name cannot be empty")])
 
     template_content = TextAreaField(
-        "Alert message", validators=[DataRequired(message="Cannot be empty"), NoCommasInPlaceHolders()]
+        "Alert message", validators=[DataRequired(message="Alert message cannot be empty"), NoCommasInPlaceHolders()]
     )
     process_type = GovukRadiosField(
         "Use priority queue?",
@@ -1229,6 +1229,11 @@ class SMSTemplateForm(BaseTemplateForm):
 
 
 class BroadcastTemplateForm(SMSTemplateForm):
+    name = GovukTextInputField("Reference", validators=[DataRequired(message="Reference cannot be empty")])
+    template_content = TextAreaField(
+        "Alert message", validators=[DataRequired(message="Alert message cannot be empty"), NoCommasInPlaceHolders()]
+    )
+
     def validate_template_content(self, field):
         OnlySMSCharacters(template_type="broadcast")(None, field)
         NoPlaceholders()(None, field)

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1153,6 +1153,7 @@ class NewBroadcastForm(StripWhitespaceForm):
             ("template", "Use a template"),
         ],
         param_extensions={"fieldset": {"legend": {"classes": "govuk-visually-hidden"}}},
+        validators=[DataRequired(message="Please select a radio button to continue")],
     )
 
     @property

--- a/app/templates/views/broadcast/new-broadcast.html
+++ b/app/templates/views/broadcast/new-broadcast.html
@@ -1,6 +1,7 @@
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
+{% from "components/error-summary.html" import errorSummary %}
 
 {% extends "withnav_template.html" %}
 
@@ -13,6 +14,8 @@
 {% endblock %}
 
 {% block maincolumn_content %}
+
+  {{ errorSummary(form) }}
 
   {% call form_wrapper(class="govuk-!-margin-top-3") %}
     {{ form.content(

--- a/app/templates/views/broadcast/write-new-broadcast.html
+++ b/app/templates/views/broadcast/write-new-broadcast.html
@@ -26,8 +26,7 @@
       <div class="govuk-grid-column-two-thirds">
         {{ form.name(param_extensions={
           "classes": "govuk-!-width-full",
-          "hint": {"text": "Your recipients will not see this"},
-          "label": {"text": "Reference"}
+          "hint": {"text": "Your recipients will not see this"}
         }) }}
         {{ textbox(
           form.template_content,

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -805,7 +805,7 @@ def test_write_new_broadcast_posts(
 @pytest.mark.parametrize(
     "content, expected_error_message",
     (
-        ("", "Cannot be empty"),
+        ("", "Alert message cannot be empty"),
         ("ŵ" * 616, "Content must be 615 characters or fewer because it contains ŵ"),
         ("w" * 1_396, "Content must be 1,395 characters or fewer"),
         ("hello ((name))", "You can’t use ((double brackets)) to personalise this message"),


### PR DESCRIPTION
This PR captures the following a11y changes:

- EAS-1392; flex for service type tag and switch service link for better mobile display
- EAS-1464; WCAG A colour contrast compliance for alert template preview link, via font weight styling
- EAS-1391; using an error summary with a clearer message for the alert template "Template or New Alert" radio selection
- EAS-1393; improving clarity for empty template form validation message