### PR TITLE
EAS-1246: Remove service stats

### DIFF
--- a/app/templates/views/platform-admin/services.html
+++ b/app/templates/views/platform-admin/services.html
@@ -10,11 +10,6 @@
   {% call(item, row_number) mapping_table(
     caption=caption,
     caption_visible=False,
-    field_headings=[
-    right_aligned_field_heading('Emails'),
-    right_aligned_field_heading('Text messages'),
-    right_aligned_field_heading('Letters')
-    ],
     field_headings_visible=False,
   ) %}
 
@@ -24,26 +19,12 @@
 
         {% call row() %}
           {% call field(border=False, colspan=3) %}
-            <a href="{{ url_for('main.service_dashboard', service_id=service['id']) }}" class="file-list-filename-large govuk-link govuk-link--no-visited-state govuk-!-padding-bottom-4">{{ service['name'] }}</a>
+            <a href="{{ url_for('main.service_dashboard', service_id=service['id']) }}" class="file-list-filename-large govuk-link govuk-link--no-visited-state govuk-!-padding-bottom-4 govuk-!-padding-top-4">{{ service['name'] }}</a>
             {% if not service['active'] %}
               <span class="heading-medium hint">&ensp;Archived</span>
             {% endif %}
           {% endcall %}
-
         {% endcall %}
-
-        {% call row() %}
-          {% for channel in ('email', 'sms', 'letter') %}
-            {% call field(border=False) %}
-              {{ big_number(
-                service['stats'][channel]['requested'],
-                smallest=True,
-                label=service['stats'][channel]['requested']|message_count_label(channel)
-              ) }}
-            {% endcall %}
-          {% endfor %}
-        {% endcall %}
-
       {% endcall %}
 
     {% endfor %}
@@ -61,23 +42,6 @@
   <h1 class="heading-medium">
     {{ page_title|capitalize }}
   </h1>
-
-
-  {% set details_content %}
-    {% call form_wrapper(method="get") %}
-      {{ form.start_date(param_extensions={"hint": {"text": "Enter start date in format YYYY-MM-DD"}}) }}
-      {{ form.end_date(param_extensions={"hint": {"text": "Enter end date in format YYYY-MM-DD"}}) }}
-      {{ form.include_from_test_key }}
-      {{ govukButton({ "text": "Filter" }) }}
-    {% endcall %}
-  {% endset %}
-
-  {{ govukDetails({
-    "summaryText": "Apply filters",
-    "html": details_content
-  }) }}
-
-  {% include "views/platform-admin/_global_stats.html" %}
 
   {{ services_table(services, page_title|capitalize) }}
 


### PR DESCRIPTION
Removal of service stats (i.e., number of emails, text messages and letters sent per service, from Platform Admin view) as these are artefacts from Notify and are irrelevant to the Emergency Alerts Service (and they were also causing DAC-reported a11y issues, so we needed to either update them to fix this or remove them entirely).