### PR TITLE
EAS 1736 Multi Tenant Dev - tenant prefixing

### DIFF
--- a/.codepipeline/buildspec-admin-build.yml
+++ b/.codepipeline/buildspec-admin-build.yml
@@ -14,7 +14,7 @@ phases:
       - echo Build started on `date`
       - echo Building Docker image...
       - docker build -t $REPOSITORY_URI:latest -t $REPOSITORY_URI:pipeline_$EXECUTION_ID -t $REPOSITORY_URI:commit_$COMMIT_ID
-        -f Dockerfile.eas-admin --build-arg ECS_ACCOUNT_NUMBER=$ACCOUNT_NUMBER RESOURCE_PREFIX=${RESOURCE_PREFIX:-eas-app} --no-cache
+        -f Dockerfile.eas-admin --build-arg ECS_ACCOUNT_NUMBER=$ACCOUNT_NUMBER --build-arg RESOURCE_PREFIX=${RESOURCE_PREFIX:-eas-app} --no-cache
         .
   post_build:
     commands:

--- a/.codepipeline/buildspec-admin-build.yml
+++ b/.codepipeline/buildspec-admin-build.yml
@@ -14,7 +14,7 @@ phases:
       - echo Build started on `date`
       - echo Building Docker image...
       - docker build -t $REPOSITORY_URI:latest -t $REPOSITORY_URI:pipeline_$EXECUTION_ID -t $REPOSITORY_URI:commit_$COMMIT_ID
-        -f Dockerfile.eas-admin --build-arg ECS_ACCOUNT_NUMBER=$ACCOUNT_NUMBER RESOURCE_PREFIX=$ECR_RESOURCE_PREFIX --no-cache
+        -f Dockerfile.eas-admin --build-arg ECS_ACCOUNT_NUMBER=$ACCOUNT_NUMBER RESOURCE_PREFIX=${ECR_RESOURCE_PREFIX:-eas-app} --no-cache
         .
   post_build:
     commands:

--- a/.codepipeline/buildspec-admin-build.yml
+++ b/.codepipeline/buildspec-admin-build.yml
@@ -14,7 +14,7 @@ phases:
       - echo Build started on `date`
       - echo Building Docker image...
       - docker build -t $REPOSITORY_URI:latest -t $REPOSITORY_URI:pipeline_$EXECUTION_ID -t $REPOSITORY_URI:commit_$COMMIT_ID
-        -f Dockerfile.eas-admin --build-arg ECS_ACCOUNT_NUMBER=$ACCOUNT_NUMBER --no-cache
+        -f Dockerfile.eas-admin --build-arg ECS_ACCOUNT_NUMBER=$ACCOUNT_NUMBER RESOURCE_PREFIX=$ECR_RESOURCE_PREFIX --no-cache
         .
   post_build:
     commands:

--- a/.codepipeline/buildspec-admin-build.yml
+++ b/.codepipeline/buildspec-admin-build.yml
@@ -14,7 +14,7 @@ phases:
       - echo Build started on `date`
       - echo Building Docker image...
       - docker build -t $REPOSITORY_URI:latest -t $REPOSITORY_URI:pipeline_$EXECUTION_ID -t $REPOSITORY_URI:commit_$COMMIT_ID
-        -f Dockerfile.eas-admin --build-arg ECS_ACCOUNT_NUMBER=$ACCOUNT_NUMBER RESOURCE_PREFIX=${ECR_RESOURCE_PREFIX:-eas-app} --no-cache
+        -f Dockerfile.eas-admin --build-arg ECS_ACCOUNT_NUMBER=$ACCOUNT_NUMBER RESOURCE_PREFIX=${RESOURCE_PREFIX:-eas-app} --no-cache
         .
   post_build:
     commands:

--- a/Dockerfile.eas-admin
+++ b/Dockerfile.eas-admin
@@ -1,5 +1,6 @@
 ARG ECS_ACCOUNT_NUMBER
-FROM ${ECS_ACCOUNT_NUMBER}.dkr.ecr.eu-west-2.amazonaws.com/eas-app-base:latest
+ARG RESOURCE_PREFIX=eas-app
+FROM ${ECS_ACCOUNT_NUMBER}.dkr.ecr.eu-west-2.amazonaws.com/${RESOURCE_PREFIX}-base:latest
 
 ENV SERVICE='admin'
 

--- a/app/config.py
+++ b/app/config.py
@@ -119,8 +119,9 @@ class Hosted(Config):
     API_HOST_NAME = "http://api.ecs.local:6011"
     ADMIN_BASE_URL = "http://admin.ecs.local:6012"
     HEADER_COLOUR = header_colors.get(os.environ.get("ENVIRONMENT"), "#81878b")
+    TENANT = f"{os.environ.get('TENANT')}." if os.environ.get("TENANT") is not None else ""
     SUBDOMAIN = f"{os.environ.get('ENVIRONMENT')}." if os.environ.get("ENVIRONMENT") != "production" else ""
-    ADMIN_EXTERNAL_URL = f"https://admin.{SUBDOMAIN}emergency-alerts.service.gov.uk"
+    ADMIN_EXTERNAL_URL = f"https://{TENANT}admin.{SUBDOMAIN}emergency-alerts.service.gov.uk"
     TEMPLATE_PREVIEW_API_HOST = "http://api.ecs.local:6013"
     ANTIVIRUS_API_HOST = "http://admin.ecs.local:6016"
     REDIS_URL = "redis://api.ecs.local:6379/0"
@@ -147,8 +148,9 @@ class Test(Config):
     ANTIVIRUS_API_HOST = "https://test-antivirus"
     ANTIVIRUS_API_KEY = "test-antivirus-secret"
     ANTIVIRUS_ENABLED = True
+    TENANT = f"{os.environ.get('TENANT')}." if os.environ.get("TENANT") is not None else ""
     SUBDOMAIN = f"{os.environ.get('ENVIRONMENT')}." if os.environ.get("ENVIRONMENT") != "production" else ""
-    ADMIN_EXTERNAL_URL = f"https://admin.{SUBDOMAIN}emergency-alerts.service.gov.uk"
+    ADMIN_EXTERNAL_URL = f"https://{TENANT}admin.{SUBDOMAIN}emergency-alerts.service.gov.uk"
     ASSET_DOMAIN = "static.example.com"
     ASSET_PATH = "https://static.example.com/"
 

--- a/app/config.py
+++ b/app/config.py
@@ -118,10 +118,10 @@ class Hosted(Config):
     HOST = "hosted"
     TENANT = f"{os.environ.get('TENANT')}." if os.environ.get("TENANT") is not None else ""
     SUBDOMAIN = (
-        f"{os.environ.get('ENVIRONMENT')}."
-        if os.environ.get("ENVIRONMENT") != "production"
-        else "dev."
+        "dev."
         if os.environ.get("ENVIRONMENT") == "development"
+        else f"{os.environ.get('ENVIRONMENT')}."
+        if os.environ.get("ENVIRONMENT") != "production"
         else ""
     )
     API_HOST_NAME = f"http://api.{TENANT}ecs.local:6011"
@@ -156,10 +156,10 @@ class Test(Config):
     ANTIVIRUS_ENABLED = True
     TENANT = f"{os.environ.get('TENANT')}." if os.environ.get("TENANT") is not None else ""
     SUBDOMAIN = (
-        f"{os.environ.get('ENVIRONMENT')}."
-        if os.environ.get("ENVIRONMENT") != "production"
-        else "dev."
+        "dev."
         if os.environ.get("ENVIRONMENT") == "development"
+        else f"{os.environ.get('ENVIRONMENT')}."
+        if os.environ.get("ENVIRONMENT") != "production"
         else ""
     )
     ADMIN_EXTERNAL_URL = f"https://{TENANT}admin.{SUBDOMAIN}emergency-alerts.service.gov.uk"

--- a/app/config.py
+++ b/app/config.py
@@ -117,13 +117,19 @@ class Config(object):
 class Hosted(Config):
     HOST = "hosted"
     TENANT = f"{os.environ.get('TENANT')}." if os.environ.get("TENANT") is not None else ""
-    SUBDOMAIN = f"{os.environ.get('ENVIRONMENT')}." if os.environ.get("ENVIRONMENT") != "production" else ""
+    SUBDOMAIN = (
+        f"{os.environ.get('ENVIRONMENT')}."
+        if os.environ.get("ENVIRONMENT") != "production"
+        else "dev."
+        if os.environ.get("ENVIRONMENT") == "development"
+        else ""
+    )
     API_HOST_NAME = f"http://api.{TENANT}ecs.local:6011"
     ADMIN_BASE_URL = f"http://admin.{TENANT}ecs.local:6012"
     HEADER_COLOUR = header_colors.get(os.environ.get("ENVIRONMENT"), "#81878b")
     ADMIN_EXTERNAL_URL = f"https://{TENANT}admin.{SUBDOMAIN}emergency-alerts.service.gov.uk"
     TEMPLATE_PREVIEW_API_HOST = f"http://api.{TENANT}ecs.local:6013"
-    ANTIVIRUS_API_HOST = "http://admin.ecs.local:6016"
+    ANTIVIRUS_API_HOST = f"http://admin.{TENANT}ecs.local:6016"
     REDIS_URL = f"redis://api.{TENANT}ecs.local:6379/0"
 
     DEBUG = False
@@ -149,7 +155,13 @@ class Test(Config):
     ANTIVIRUS_API_KEY = "test-antivirus-secret"
     ANTIVIRUS_ENABLED = True
     TENANT = f"{os.environ.get('TENANT')}." if os.environ.get("TENANT") is not None else ""
-    SUBDOMAIN = f"{os.environ.get('ENVIRONMENT')}." if os.environ.get("ENVIRONMENT") != "production" else ""
+    SUBDOMAIN = (
+        f"{os.environ.get('ENVIRONMENT')}."
+        if os.environ.get("ENVIRONMENT") != "production"
+        else "dev."
+        if os.environ.get("ENVIRONMENT") == "development"
+        else ""
+    )
     ADMIN_EXTERNAL_URL = f"https://{TENANT}admin.{SUBDOMAIN}emergency-alerts.service.gov.uk"
     ASSET_DOMAIN = "static.example.com"
     ASSET_PATH = "https://static.example.com/"

--- a/app/config.py
+++ b/app/config.py
@@ -116,15 +116,15 @@ class Config(object):
 
 class Hosted(Config):
     HOST = "hosted"
-    API_HOST_NAME = "http://api.ecs.local:6011"
-    ADMIN_BASE_URL = "http://admin.ecs.local:6012"
-    HEADER_COLOUR = header_colors.get(os.environ.get("ENVIRONMENT"), "#81878b")
     TENANT = f"{os.environ.get('TENANT')}." if os.environ.get("TENANT") is not None else ""
     SUBDOMAIN = f"{os.environ.get('ENVIRONMENT')}." if os.environ.get("ENVIRONMENT") != "production" else ""
+    API_HOST_NAME = f"http://api.{TENANT}ecs.local:6011"
+    ADMIN_BASE_URL = f"http://admin.{TENANT}ecs.local:6012"
+    HEADER_COLOUR = header_colors.get(os.environ.get("ENVIRONMENT"), "#81878b")
     ADMIN_EXTERNAL_URL = f"https://{TENANT}admin.{SUBDOMAIN}emergency-alerts.service.gov.uk"
-    TEMPLATE_PREVIEW_API_HOST = "http://api.ecs.local:6013"
+    TEMPLATE_PREVIEW_API_HOST = f"http://api.{TENANT}ecs.local:6013"
     ANTIVIRUS_API_HOST = "http://admin.ecs.local:6016"
-    REDIS_URL = "redis://api.ecs.local:6379/0"
+    REDIS_URL = f"redis://api.{TENANT}ecs.local:6379/0"
 
     DEBUG = False
     SESSION_COOKIE_SECURE = True

--- a/tests/app/notify_client/test_invite_client.py
+++ b/tests/app/notify_client/test_invite_client.py
@@ -33,6 +33,7 @@ def test_client_creates_invite(
 
     invite_api_client.create_invite("12345", "67890", "test@example.com", {"send_messages"}, "sms_auth", [fake_uuid])
 
+    tenant = f"{os.environ.get('TENANT')}." if os.environ.get("TENANT") is not None else ""
     subdomain = f"{os.environ.get('ENVIRONMENT')}." if os.environ.get("ENVIRONMENT") != "production" else ""
 
     mock_post.assert_called_once_with(
@@ -44,7 +45,7 @@ def test_client_creates_invite(
             "service": "67890",
             "created_by": ANY,
             "permissions": "send_emails,send_letters,send_texts",
-            "invite_link_host": f"https://admin.{subdomain}emergency-alerts.service.gov.uk",
+            "invite_link_host": f"https://{tenant}admin.{subdomain}emergency-alerts.service.gov.uk",
             "folder_permissions": [fake_uuid],
         },
     )

--- a/tests/app/notify_client/test_invite_client.py
+++ b/tests/app/notify_client/test_invite_client.py
@@ -35,10 +35,10 @@ def test_client_creates_invite(
 
     tenant = f"{os.environ.get('TENANT')}." if os.environ.get("TENANT") is not None else ""
     subdomain = (
-        f"{os.environ.get('ENVIRONMENT')}."
-        if os.environ.get("ENVIRONMENT") != "production"
-        else "dev."
+        "dev."
         if os.environ.get("ENVIRONMENT") == "development"
+        else f"{os.environ.get('ENVIRONMENT')}."
+        if os.environ.get("ENVIRONMENT") != "production"
         else ""
     )
 

--- a/tests/app/notify_client/test_invite_client.py
+++ b/tests/app/notify_client/test_invite_client.py
@@ -34,7 +34,13 @@ def test_client_creates_invite(
     invite_api_client.create_invite("12345", "67890", "test@example.com", {"send_messages"}, "sms_auth", [fake_uuid])
 
     tenant = f"{os.environ.get('TENANT')}." if os.environ.get("TENANT") is not None else ""
-    subdomain = f"{os.environ.get('ENVIRONMENT')}." if os.environ.get("ENVIRONMENT") != "production" else ""
+    subdomain = (
+        f"{os.environ.get('ENVIRONMENT')}."
+        if os.environ.get("ENVIRONMENT") != "production"
+        else "dev."
+        if os.environ.get("ENVIRONMENT") == "development"
+        else ""
+    )
 
     mock_post.assert_called_once_with(
         url="/service/{}/invite".format("67890"),

--- a/tests/app/notify_client/test_user_client.py
+++ b/tests/app/notify_client/test_user_client.py
@@ -87,7 +87,13 @@ def test_client_passes_admin_url_when_sending_email_auth(
     user_api_client.send_verify_code(fake_uuid, "email", "ignored@example.com")
 
     tenant = f"{os.environ.get('TENANT')}." if os.environ.get("TENANT") is not None else ""
-    subdomain = f"{os.environ.get('ENVIRONMENT')}." if os.environ.get("ENVIRONMENT") != "production" else ""
+    subdomain = (
+        f"{os.environ.get('ENVIRONMENT')}."
+        if os.environ.get("ENVIRONMENT") != "production"
+        else "dev."
+        if os.environ.get("ENVIRONMENT") == "development"
+        else ""
+    )
 
     mock_post.assert_called_once_with(
         "/user/{}/email-code".format(fake_uuid),
@@ -315,7 +321,13 @@ def test_reset_password(
     user_api_client.send_reset_password_url("test@example.com")
 
     tenant = f"{os.environ.get('TENANT')}." if os.environ.get("TENANT") is not None else ""
-    subdomain = f"{os.environ.get('ENVIRONMENT')}." if os.environ.get("ENVIRONMENT") != "production" else ""
+    subdomain = (
+        f"{os.environ.get('ENVIRONMENT')}."
+        if os.environ.get("ENVIRONMENT") != "production"
+        else "dev."
+        if os.environ.get("ENVIRONMENT") == "development"
+        else ""
+    )
 
     mock_post.assert_called_once_with(
         "/user/reset-password",
@@ -335,7 +347,13 @@ def test_send_registration_email(
     user_api_client.send_verify_email(fake_uuid, "test@example.com")
 
     tenant = f"{os.environ.get('TENANT')}." if os.environ.get("TENANT") is not None else ""
-    subdomain = f"{os.environ.get('ENVIRONMENT')}." if os.environ.get("ENVIRONMENT") != "production" else ""
+    subdomain = (
+        f"{os.environ.get('ENVIRONMENT')}."
+        if os.environ.get("ENVIRONMENT") != "production"
+        else "dev."
+        if os.environ.get("ENVIRONMENT") == "development"
+        else ""
+    )
 
     mock_post.assert_called_once_with(
         f"/user/{fake_uuid}/email-verification",

--- a/tests/app/notify_client/test_user_client.py
+++ b/tests/app/notify_client/test_user_client.py
@@ -86,13 +86,14 @@ def test_client_passes_admin_url_when_sending_email_auth(
 
     user_api_client.send_verify_code(fake_uuid, "email", "ignored@example.com")
 
+    tenant = f"{os.environ.get('TENANT')}." if os.environ.get("TENANT") is not None else ""
     subdomain = f"{os.environ.get('ENVIRONMENT')}." if os.environ.get("ENVIRONMENT") != "production" else ""
 
     mock_post.assert_called_once_with(
         "/user/{}/email-code".format(fake_uuid),
         data={
             "to": "ignored@example.com",
-            "email_auth_link_host": f"https://admin.{subdomain}emergency-alerts.service.gov.uk",
+            "email_auth_link_host": f"https://{tenant}admin.{subdomain}emergency-alerts.service.gov.uk",
         },
     )
 
@@ -313,13 +314,14 @@ def test_reset_password(
 
     user_api_client.send_reset_password_url("test@example.com")
 
+    tenant = f"{os.environ.get('TENANT')}." if os.environ.get("TENANT") is not None else ""
     subdomain = f"{os.environ.get('ENVIRONMENT')}." if os.environ.get("ENVIRONMENT") != "production" else ""
 
     mock_post.assert_called_once_with(
         "/user/reset-password",
         data={
             "email": "test@example.com",
-            "admin_base_url": f"https://admin.{subdomain}emergency-alerts.service.gov.uk",
+            "admin_base_url": f"https://{tenant}admin.{subdomain}emergency-alerts.service.gov.uk",
         },
     )
 
@@ -332,12 +334,13 @@ def test_send_registration_email(
 
     user_api_client.send_verify_email(fake_uuid, "test@example.com")
 
+    tenant = f"{os.environ.get('TENANT')}." if os.environ.get("TENANT") is not None else ""
     subdomain = f"{os.environ.get('ENVIRONMENT')}." if os.environ.get("ENVIRONMENT") != "production" else ""
 
     mock_post.assert_called_once_with(
         f"/user/{fake_uuid}/email-verification",
         data={
             "to": "test@example.com",
-            "admin_base_url": f"https://admin.{subdomain}emergency-alerts.service.gov.uk",
+            "admin_base_url": f"https://{tenant}admin.{subdomain}emergency-alerts.service.gov.uk",
         },
     )

--- a/tests/app/notify_client/test_user_client.py
+++ b/tests/app/notify_client/test_user_client.py
@@ -88,10 +88,10 @@ def test_client_passes_admin_url_when_sending_email_auth(
 
     tenant = f"{os.environ.get('TENANT')}." if os.environ.get("TENANT") is not None else ""
     subdomain = (
-        f"{os.environ.get('ENVIRONMENT')}."
-        if os.environ.get("ENVIRONMENT") != "production"
-        else "dev."
+        "dev."
         if os.environ.get("ENVIRONMENT") == "development"
+        else f"{os.environ.get('ENVIRONMENT')}."
+        if os.environ.get("ENVIRONMENT") != "production"
         else ""
     )
 
@@ -322,10 +322,10 @@ def test_reset_password(
 
     tenant = f"{os.environ.get('TENANT')}." if os.environ.get("TENANT") is not None else ""
     subdomain = (
-        f"{os.environ.get('ENVIRONMENT')}."
-        if os.environ.get("ENVIRONMENT") != "production"
-        else "dev."
+        "dev."
         if os.environ.get("ENVIRONMENT") == "development"
+        else f"{os.environ.get('ENVIRONMENT')}."
+        if os.environ.get("ENVIRONMENT") != "production"
         else ""
     )
 
@@ -348,10 +348,10 @@ def test_send_registration_email(
 
     tenant = f"{os.environ.get('TENANT')}." if os.environ.get("TENANT") is not None else ""
     subdomain = (
-        f"{os.environ.get('ENVIRONMENT')}."
-        if os.environ.get("ENVIRONMENT") != "production"
-        else "dev."
+        "dev."
         if os.environ.get("ENVIRONMENT") == "development"
+        else f"{os.environ.get('ENVIRONMENT')}."
+        if os.environ.get("ENVIRONMENT") != "production"
         else ""
     )
 

--- a/tests/app/test_webauthn_server.py
+++ b/tests/app/test_webauthn_server.py
@@ -10,7 +10,13 @@ def app_with_mock_config(mocker):
     app = mocker.Mock()
 
     tenant = f"{os.environ.get('TENANT')}." if os.environ.get("TENANT") is not None else ""
-    subdomain = f"{os.environ.get('ENVIRONMENT')}." if os.environ.get("ENVIRONMENT") != "production" else ""
+    subdomain = (
+        f"{os.environ.get('ENVIRONMENT')}."
+        if os.environ.get("ENVIRONMENT") != "production"
+        else "dev."
+        if os.environ.get("ENVIRONMENT") == "development"
+        else ""
+    )
 
     app.config = {
         "ADMIN_EXTERNAL_URL": f"https://{tenant}admin.{subdomain}emergency-alerts.service.gov.uk",

--- a/tests/app/test_webauthn_server.py
+++ b/tests/app/test_webauthn_server.py
@@ -9,10 +9,11 @@ from app import webauthn_server
 def app_with_mock_config(mocker):
     app = mocker.Mock()
 
+    tenant = f"{os.environ.get('TENANT')}." if os.environ.get("TENANT") is not None else ""
     subdomain = f"{os.environ.get('ENVIRONMENT')}." if os.environ.get("ENVIRONMENT") != "production" else ""
 
     app.config = {
-        "ADMIN_EXTERNAL_URL": f"https://admin.{subdomain}emergency-alerts.service.gov.uk",
+        "ADMIN_EXTERNAL_URL": f"https://{tenant}admin.{subdomain}emergency-alerts.service.gov.uk",
         "HOST": "local",
     }
     return app
@@ -30,6 +31,7 @@ def test_server_relying_party_id(
     mocker,
 ):
     webauthn_server.init_app(app_with_mock_config)
-    rp_id = "admin.{}emergency-alerts.service.gov.uk"
+    rp_id = "{}admin.{}emergency-alerts.service.gov.uk"
+    tenant = f"{os.environ.get('TENANT')}." if os.environ.get("TENANT") is not None else ""
     subdomain = f"{os.environ.get('ENVIRONMENT')}." if os.environ.get("ENVIRONMENT") != "production" else ""
-    assert app_with_mock_config.webauthn_server.rp.id == rp_id.format(subdomain).lower()
+    assert app_with_mock_config.webauthn_server.rp.id == rp_id.format(tenant, subdomain).lower()

--- a/tests/app/test_webauthn_server.py
+++ b/tests/app/test_webauthn_server.py
@@ -11,10 +11,10 @@ def app_with_mock_config(mocker):
 
     tenant = f"{os.environ.get('TENANT')}." if os.environ.get("TENANT") is not None else ""
     subdomain = (
-        f"{os.environ.get('ENVIRONMENT')}."
-        if os.environ.get("ENVIRONMENT") != "production"
-        else "dev."
+        "dev."
         if os.environ.get("ENVIRONMENT") == "development"
+        else f"{os.environ.get('ENVIRONMENT')}."
+        if os.environ.get("ENVIRONMENT") != "production"
         else ""
     )
 


### PR DESCRIPTION
This PR amends the Dockerfiles and buildspec.yml files to enable dynamic resource prefixes when referring to (primarily) the appropriate ECR repository to use for the base image. This way, modifications can be made to the utils package and deployed to the particular user's development environment, and it will be referenced appropriately when building other application components (e.g., Admin, API) using it.