### PR TITLE
EAS-2028 Apply version upgrades

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,3 +27,4 @@ repos:
       name: check-requirements
       entry: ./scripts/check-requirements.sh
       language: script
+      pass_filenames: false

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -510,8 +510,8 @@ def setup_blueprints(application):
     from app.main import no_cookie as no_cookie_blueprint
     from app.status import status as status_blueprint
 
-    main_blueprint.before_request(make_session_permanent)
-    main_blueprint.after_request(save_service_or_org_after_request)
+    # main_blueprint.before_request(make_session_permanent)
+    # main_blueprint.after_request(save_service_or_org_after_request)
 
     application.register_blueprint(main_blueprint)
     # no_cookie_blueprint specifically doesn't have `make_session_permanent` or `save_service_or_org_after_request`

--- a/app/broadcast_areas/utils.py
+++ b/app/broadcast_areas/utils.py
@@ -14,7 +14,7 @@ def _convert_custom_areas_to_wards(areas):
     results = set()
 
     for area in areas:
-        if type(area) == CustomBroadcastArea:
+        if type(area) is CustomBroadcastArea:
             results |= set(area.overlapping_electoral_wards)
         else:
             results |= {area}

--- a/app/formatters.py
+++ b/app/formatters.py
@@ -15,7 +15,8 @@ from emergency_alerts_utils.formatters import nl2br as utils_nl2br
 from emergency_alerts_utils.recipients import InvalidPhoneError, validate_phone_number
 from emergency_alerts_utils.take import Take
 from emergency_alerts_utils.timezones import utc_string_to_aware_gmt_datetime
-from flask import Markup, url_for
+from flask import url_for
+from markupsafe import Markup
 
 
 def convert_to_boolean(value):

--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -1,7 +1,30 @@
-from flask import Blueprint
+from flask import Blueprint, request, session
 
 main = Blueprint("main", __name__)
 no_cookie = Blueprint("no_cookie", __name__)
+
+
+def make_session_permanent():
+    session.permanent = True
+
+
+def save_service_or_org_after_request(response):
+    # Only save the current session if the request is 200
+    service_id = request.view_args.get("service_id", None) if request.view_args else None
+    organisation_id = request.view_args.get("org_id", None) if request.view_args else None
+    if response.status_code == 200:
+        if service_id:
+            session["service_id"] = service_id
+            session["organisation_id"] = None
+        elif organisation_id:
+            session["service_id"] = None
+            session["organisation_id"] = organisation_id
+    return response
+
+
+main.before_request(make_session_permanent)
+main.after_request(save_service_or_org_after_request)
+
 
 from app.main.views import (  # noqa isort:skip
     add_service,

--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -1,5 +1,6 @@
-from flask import Markup, abort, flash, redirect, render_template, request, url_for
+from flask import abort, flash, redirect, render_template, request, url_for
 from flask_login import current_user
+from markupsafe import Markup
 
 from app import (
     api_key_api_client,

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -8,7 +8,6 @@ from emergency_alerts_utils.template import (
     SMSBodyPreviewTemplate,
 )
 from flask import (
-    Markup,
     Response,
     abort,
     flash,
@@ -20,6 +19,7 @@ from flask import (
     url_for,
 )
 from flask_login import current_user
+from markupsafe import Markup
 from notifications_python_client.errors import HTTPError
 
 from app import (

--- a/app/main/views/organisations.py
+++ b/app/main/views/organisations.py
@@ -4,7 +4,6 @@ from functools import partial
 from typing import Optional
 
 from flask import (
-    Markup,
     current_app,
     flash,
     redirect,
@@ -14,6 +13,7 @@ from flask import (
     url_for,
 )
 from flask_login import current_user
+from markupsafe import Markup
 from notifications_python_client.errors import HTTPError
 from werkzeug import Response
 from werkzeug.exceptions import abort

--- a/app/main/views/sign_in.py
+++ b/app/main/views/sign_in.py
@@ -1,14 +1,6 @@
-from flask import (
-    Markup,
-    abort,
-    flash,
-    redirect,
-    render_template,
-    request,
-    session,
-    url_for,
-)
+from flask import abort, flash, redirect, render_template, request, session, url_for
 from flask_login import current_user
+from markupsafe import Markup
 
 from app import login_manager
 from app.main import main

--- a/app/utils/govuk_frontend_field.py
+++ b/app/utils/govuk_frontend_field.py
@@ -1,7 +1,8 @@
 import copy
 from abc import ABC, abstractmethod
 
-from flask import Markup, render_template_string
+from flask import render_template_string
+from markupsafe import Markup
 
 from app.utils import merge_jsonlike
 

--- a/requirements.in
+++ b/requirements.in
@@ -4,15 +4,16 @@
 ago==0.0.95
 govuk-bank-holidays==0.11
 humanize==4.4.0
-Flask==2.2.2
-Flask-WTF==1.0.1
-wtforms==3.0.1
-Flask-Login==0.6.2
-Werkzeug==2.2.2
+Flask==3.0.2
+Flask-WTF==1.2.1
+wtforms==3.1.2
+Flask-Login==0.6.3
+Werkzeug==3.0.2
 jinja2==3.1.2
 Pillow==9.3.0
+MarkupSafe==2.1.5
 
-blinker==1.5
+blinker==1.7.0
 pyexcel==0.7.0
 pyexcel-io==0.6.6
 pyexcel-xls==0.7.0
@@ -45,5 +46,5 @@ freezegun==1.2.2
 flake8==7.0.0
 flake8-bugbear==22.10.27
 flake8-print==5.0.0
-moto==4.0.9
+moto==5.0.4
 requests-mock==1.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,9 +14,10 @@ beautifulsoup4==4.11.1
     # via -r requirements.in
 black==23.3.0
     # via -r requirements.in
-blinker==1.5
+blinker==1.7.0
     # via
     #   -r requirements.in
+    #   flask
     #   gds-metrics
 boto3==1.26.100
     # via moto
@@ -57,7 +58,7 @@ execnet==1.9.0
     # via pytest-xdist
 fido2==1.1.0
     # via -r requirements.in
-flake8==6.0.0
+flake8==7.0.0
     # via
     #   -r requirements.in
     #   flake8-bugbear
@@ -66,15 +67,15 @@ flake8-bugbear==22.10.27
     # via -r requirements.in
 flake8-print==5.0.0
     # via -r requirements.in
-flask==2.2.2
+flask==3.0.2
     # via
     #   -r requirements.in
     #   flask-login
     #   flask-wtf
     #   gds-metrics
-flask-login==0.6.2
+flask-login==0.6.3
     # via -r requirements.in
-flask-wtf==1.0.1
+flask-wtf==1.2.1
     # via -r requirements.in
 freezegun==1.2.2
     # via -r requirements.in
@@ -121,15 +122,15 @@ lxml==4.9.1
     # via
     #   pyexcel-ezodf
     #   pyexcel-ods3
-markupsafe==2.1.1
+markupsafe==2.1.5
     # via
+    #   -r requirements.in
     #   jinja2
-    #   moto
     #   werkzeug
     #   wtforms
 mccabe==0.7.0
     # via flake8
-moto==4.0.9
+moto==5.0.4
     # via -r requirements.in
 mypy-extensions==1.0.0
     # via black
@@ -153,7 +154,7 @@ prometheus-client==0.15.0
     # via
     #   -r requirements.in
     #   gds-metrics
-pycodestyle==2.10.0
+pycodestyle==2.11.1
     # via
     #   flake8
     #   flake8-print
@@ -176,7 +177,7 @@ pyexcel-xls==0.7.0
     # via -r requirements.in
 pyexcel-xlsx==0.6.0
     # via -r requirements.in
-pyflakes==3.0.1
+pyflakes==3.2.0
     # via flake8
 pyjwt==2.4.0
     # via notifications-python-client
@@ -200,9 +201,7 @@ python-dateutil==2.8.2
     #   freezegun
     #   moto
 pytz==2022.6
-    # via
-    #   -r requirements.in
-    #   moto
+    # via -r requirements.in
 pyyaml==6.0.1
     # via responses
 requests==2.28.1
@@ -242,13 +241,13 @@ urllib3==1.26.9
     #   botocore
     #   requests
     #   responses
-werkzeug==2.2.2
+werkzeug==3.0.2
     # via
     #   -r requirements.in
     #   flask
     #   flask-login
     #   moto
-wtforms==3.0.1
+wtforms==3.1.2
     # via
     #   -r requirements.in
     #   flask-wtf

--- a/scripts/check-requirements.sh
+++ b/scripts/check-requirements.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
 
+STAGED_FILES=$(git diff-index --name-only --cached --diff-filter=ACMR HEAD -- )
 STAGED_REQ_FILES=0
 
-for FILE in "$@"
+for FILE in $STAGED_FILES
 do
     if [ "$FILE" = "requirements.in" ]; then
         STAGED_REQ_FILES=$((STAGED_REQ_FILES+1))

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -2115,7 +2115,7 @@ def test_send_test_works_as_letter_preview(
 
     assert response.get_data(as_text=True) == "foo"
     assert mocked_preview.call_args[0][0].id == template_id
-    assert type(mocked_preview.call_args[0][0]) == LetterImageTemplate
+    assert type(mocked_preview.call_args[0][0]) is LetterImageTemplate
     assert mocked_preview.call_args[0][0].values == {"addressline1": "Jo Lastname"}
     assert mocked_preview.call_args[0][1] == filetype
 
@@ -2719,7 +2719,7 @@ def test_should_show_preview_letter_message(
     assert response.get_data(as_text=True) == "foo"
     mocked_preview.assert_called_once()
     assert mocked_preview.call_args[0][0].id == template_id
-    assert type(mocked_preview.call_args[0][0]) == LetterPreviewTemplate
+    assert type(mocked_preview.call_args[0][0]) is LetterPreviewTemplate
     assert mocked_preview.call_args[0][1] == filetype
     assert mocked_preview.call_args[0][0].values == expected_values
     assert mocked_preview.call_args[1] == {"page": expected_page}

--- a/tests/app/main/views/test_two_factor.py
+++ b/tests/app/main/views/test_two_factor.py
@@ -326,7 +326,7 @@ def test_two_factor_sms_should_activate_pending_user(
 
 @pytest.mark.parametrize(
     "extra_args, expected_encoded_next_arg",
-    (({}, ""), ({"next": "https://example.com"}, "?next=https%3A%2F%2Fexample.com")),
+    (({}, ""), ({"next": "https://example.com"}, "?next=https://example.com")),
 )
 def test_valid_two_factor_email_link_shows_interstitial(
     client_request,

--- a/tests/app/models/test_broadcast_message.py
+++ b/tests/app/models/test_broadcast_message.py
@@ -80,7 +80,7 @@ def test_areas_treats_missing_ids_as_custom_broadcast(notify_admin):
     )
 
     assert len(list(broadcast_message.areas)) == 2
-    assert type(broadcast_message.areas) == CustomBroadcastAreas
+    assert type(broadcast_message.areas) is CustomBroadcastAreas
 
 
 @pytest.mark.parametrize(

--- a/tests/app/models/test_webauthn_credential.py
+++ b/tests/app/models/test_webauthn_credential.py
@@ -49,8 +49,8 @@ def test_from_registration_encodes_as_unicode(webauthn_dev_server):
 
     serialized_credential = credential.serialize()
 
-    assert type(serialized_credential["credential_data"]) == str
-    assert type(serialized_credential["registration_response"]) == str
+    assert type(serialized_credential["credential_data"]) is str
+    assert type(serialized_credential["registration_response"]) is str
 
 
 def test_from_registration_handles_library_errors():

--- a/tests/app/s3_client/test_s3_letter_upload_client.py
+++ b/tests/app/s3_client/test_s3_letter_upload_client.py
@@ -5,7 +5,7 @@ import boto3
 import botocore
 import pytest
 from flask import current_app
-from moto import mock_s3
+from moto import mock_aws
 
 from app.s3_client.s3_letter_upload_client import (
     LetterMetadata,
@@ -102,7 +102,7 @@ def test_lettermetadata_unquotes_special_keys():
     assert metadata.get("recipient") == "£hi"
 
 
-@mock_s3
+@mock_aws
 @pytest.mark.parametrize(
     "will_raise_custom_error,expected_exception",
     [(True, LetterNotFoundError), (False, botocore.exceptions.ClientError)],

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -380,7 +380,6 @@ EXCLUDED_ENDPOINTS = tuple(
 
 
 def flask_app():
-    # app = Flask("./application.py")
     app = Flask("app")
     create_app(app)
 

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -380,6 +380,7 @@ EXCLUDED_ENDPOINTS = tuple(
 
 
 def flask_app():
+    # app = Flask("./application.py")
     app = Flask("app")
     create_app(app)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,7 +46,6 @@ def notify_admin_without_context():
     You probably won't need to use this fixture, unless you need to use the flask.appcontext_pushed hook. Possibly if
     you're patching something on `g`. https://flask.palletsprojects.com/en/1.1.x/testing/#faking-resources-and-context
     """
-    # app = Flask("app/application.py")
     app = Flask("app")
     create_app(app)
     app.test_client_class = TestClient

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,12 +40,13 @@ class ElementNotFound(Exception):
     pass
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def notify_admin_without_context():
     """
     You probably won't need to use this fixture, unless you need to use the flask.appcontext_pushed hook. Possibly if
     you're patching something on `g`. https://flask.palletsprojects.com/en/1.1.x/testing/#faking-resources-and-context
     """
+    # app = Flask("app/application.py")
     app = Flask("app")
     create_app(app)
     app.test_client_class = TestClient
@@ -53,7 +54,7 @@ def notify_admin_without_context():
     return app
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def notify_admin(notify_admin_without_context):
     with notify_admin_without_context.app_context():
         yield notify_admin_without_context


### PR DESCRIPTION
Upgrade Flask (and others) to pull in the latest version of Werkzeug (required to be upgraded to latest version https://github.com/alphagov/emergency-alerts-api/security/dependabot/2).

The required upgrade cascaded through to the following related packages:
Flask==3.0.2
Flask-WTF==1.2.1
wtforms==3.1.2
Flask-Login==0.6.3
Werkzeug==3.0.2

This PR also addresses the breaking changes introduced by some of the above upgrades.