### PR TITLE
EAS-2071 Remove 'organisation' link from platform admin view

### DIFF
--- a/app/templates/views/platform-admin/_base_template.html
+++ b/app/templates/views/platform-admin/_base_template.html
@@ -15,7 +15,6 @@
           <ul>
             {% for link_text, url in [
               ('Search', url_for('main.platform_admin_search')),
-              ('Organisations', url_for('main.organisations')),
               ('Live services', url_for('main.live_services')),
               ('Trial mode services', url_for('main.trial_services')),
               ('Clear cache', url_for('main.clear_cache'))


### PR DESCRIPTION
Remove 'organisation' link from platform admin view.

Note: No unit tests are affected by this change.