### PR TITLE
Update pyproj requirement from 3.4.0 to 3.6.1

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -25,7 +25,7 @@ git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191082fd169b86
 notifications-python-client==8.0.0
 rtreelib==0.2.0
 fido2==1.1.0
-pyproj==3.4.0
+pyproj==3.6.1
 postcode-validator==0.0.4
 
 itsdangerous==2.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -183,7 +183,7 @@ pyflakes==3.2.0
     # via flake8
 pyjwt==2.4.0
     # via notifications-python-client
-pyproj==3.4.0
+pyproj==3.6.1
     # via -r requirements.in
 pytest==7.2.0
     # via


### PR DESCRIPTION
Update pyproj to follow the security patch in /emergency-alerts-utils base repository.