### PR TITLE
Change names based on utils changes

### DIFF
--- a/app/main/views/feedback.py
+++ b/app/main/views/feedback.py
@@ -1,7 +1,8 @@
+import os
 from datetime import datetime
 
 import pytz
-from emergency_alerts_utils.clients.zendesk.zendesk_client import NotifySupportTicket
+from emergency_alerts_utils.clients.zendesk.zendesk_client import EASSupportTicket
 from flask import redirect, render_template, request, session, url_for
 from flask_login import current_user
 from govuk_bank_holidays.bank_holidays import BankHolidays
@@ -83,6 +84,7 @@ def feedback(ticket_type):
         (
             ticket_type != QUESTION_TICKET_TYPE,
             not in_business_hours(),
+            os.environ.get("ENVIRONMENT") == "production",  # Only raise a p1 in prod
             severe,
         )
     )
@@ -108,7 +110,7 @@ def feedback(ticket_type):
             out_of_hours_emergency=out_of_hours_emergency,
         )
 
-        ticket = NotifySupportTicket(
+        ticket = EASSupportTicket(
             subject="Emergency Alerts feedback",
             message=feedback_msg,
             ticket_type=get_zendesk_ticket_type(ticket_type),
@@ -216,6 +218,6 @@ def get_zendesk_ticket_type(ticket_type):
     # Emergency Alerts problem because they are designed to group multiple incident tickets together,
     # allowing them to be solved as a group.
     if ticket_type == PROBLEM_TICKET_TYPE:
-        return NotifySupportTicket.TYPE_INCIDENT
+        return EASSupportTicket.TYPE_INCIDENT
 
-    return NotifySupportTicket.TYPE_QUESTION
+    return EASSupportTicket.TYPE_QUESTION

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 from datetime import datetime
 
-from emergency_alerts_utils.clients.zendesk.zendesk_client import NotifySupportTicket
+from emergency_alerts_utils.clients.zendesk.zendesk_client import EASSupportTicket
 from emergency_alerts_utils.timezones import utc_string_to_aware_gmt_datetime
 from flask import (
     abort,
@@ -156,10 +156,10 @@ def request_to_go_live(service_id):
 def submit_request_to_go_live(service_id):
     ticket_message = render_template("support-tickets/go-live-request.txt") + "\n"
 
-    ticket = NotifySupportTicket(
+    ticket = EASSupportTicket(
         subject=f"Request to go live - {current_service.name}",
         message=ticket_message,
-        ticket_type=NotifySupportTicket.TYPE_QUESTION,
+        ticket_type=EASSupportTicket.TYPE_QUESTION,
         user_name=current_user.name,
         user_email=current_user.email_address,
         requester_sees_message_content=False,

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -3,7 +3,7 @@ from unittest.mock import ANY, Mock, PropertyMock, call
 from uuid import uuid4
 
 import pytest
-from emergency_alerts_utils.clients.zendesk.zendesk_client import NotifySupportTicket
+from emergency_alerts_utils.clients.zendesk.zendesk_client import EASSupportTicket
 from flask import url_for
 from freezegun import freeze_time
 from notifications_python_client.errors import HTTPError
@@ -1319,7 +1319,7 @@ def test_should_redirect_after_request_to_go_live(
             new_callable=PropertyMock,
             return_value=volume,
         )
-    mock_create_ticket = mocker.spy(NotifySupportTicket, "__init__")
+    mock_create_ticket = mocker.spy(EASSupportTicket, "__init__")
     mock_send_ticket_to_zendesk = mocker.patch(
         "app.main.views.service_settings.zendesk_client.send_ticket_to_zendesk",
         autospec=True,
@@ -1393,7 +1393,7 @@ def test_request_to_go_live_displays_go_live_notes_in_zendesk_ticket(
             request_to_go_live_notes=go_live_note,
         ),
     )
-    mock_create_ticket = mocker.spy(NotifySupportTicket, "__init__")
+    mock_create_ticket = mocker.spy(EASSupportTicket, "__init__")
     mock_send_ticket_to_zendesk = mocker.patch(
         "app.main.views.service_settings.zendesk_client.send_ticket_to_zendesk",
         autospec=True,
@@ -1469,7 +1469,7 @@ def test_request_to_go_live_displays_mou_signatories(
         "app.main.views.service_settings.zendesk_client.send_ticket_to_zendesk",
         autospec=True,
     )
-    mock_create_ticket = mocker.spy(NotifySupportTicket, "__init__")
+    mock_create_ticket = mocker.spy(EASSupportTicket, "__init__")
     client_request.post("main.request_to_go_live", service_id=SERVICE_ONE_ID, _follow_redirects=True)
 
     assert (

--- a/tests/app/main/views/test_feedback.py
+++ b/tests/app/main/views/test_feedback.py
@@ -292,7 +292,7 @@ def test_email_address_must_be_valid_if_provided_to_support_form(
         (PROBLEM_TICKET_TYPE, "no", False, False),
         (QUESTION_TICKET_TYPE, "no", False, False),
         # out of hours, only problems can be emergencies
-        (PROBLEM_TICKET_TYPE, "yes", False, True),
+        (PROBLEM_TICKET_TYPE, "yes", False, False),
         (QUESTION_TICKET_TYPE, "yes", False, False),
     ],
 )

--- a/tests/app/main/views/test_feedback.py
+++ b/tests/app/main/views/test_feedback.py
@@ -2,7 +2,7 @@ from functools import partial
 from unittest.mock import ANY, PropertyMock
 
 import pytest
-from emergency_alerts_utils.clients.zendesk.zendesk_client import NotifySupportTicket
+from emergency_alerts_utils.clients.zendesk.zendesk_client import EASSupportTicket
 from flask import url_for
 from freezegun import freeze_time
 
@@ -133,7 +133,7 @@ def test_get_feedback_page(client_request, ticket_type, expected_status_code):
 )
 def test_passed_non_logged_in_user_details_through_flow(client_request, mocker, ticket_type, zendesk_ticket_type):
     client_request.logout()
-    mock_create_ticket = mocker.spy(NotifySupportTicket, "__init__")
+    mock_create_ticket = mocker.spy(EASSupportTicket, "__init__")
     mock_send_ticket_to_zendesk = mocker.patch(
         "app.main.views.feedback.zendesk_client.send_ticket_to_zendesk",
         autospec=True,
@@ -187,7 +187,7 @@ def test_passes_user_details_through_flow(
     zendesk_ticket_type,
     data,
 ):
-    mock_create_ticket = mocker.spy(NotifySupportTicket, "__init__")
+    mock_create_ticket = mocker.spy(EASSupportTicket, "__init__")
     mock_send_ticket_to_zendesk = mocker.patch(
         "app.main.views.feedback.zendesk_client.send_ticket_to_zendesk",
         autospec=True,
@@ -307,7 +307,7 @@ def test_urgency(
 ):
     mocker.patch("app.main.views.feedback.in_business_hours", return_value=is_in_business_hours)
 
-    mock_ticket = mocker.patch("app.main.views.feedback.NotifySupportTicket")
+    mock_ticket = mocker.patch("app.main.views.feedback.EASSupportTicket")
     mocker.patch(
         "app.main.views.feedback.zendesk_client.send_ticket_to_zendesk",
         autospec=True,


### PR DESCRIPTION
This PR depends on https://github.com/alphagov/emergency-alerts-utils/pull/81 being deployed first, as there are naming changes in the Utils pull request that are referenced by this pull request. This PR will be checking against the main branch of the Utils repository, which doesn't have the referenced naming changes. This is why the PR checks are failing here (as of this comment).