### PR TITLE
EAS-2290 Set SameSite cookie directive to 'Strict'

### DIFF
--- a/app/assets/javascripts/analytics/analytics.js
+++ b/app/assets/javascripts/analytics/analytics.js
@@ -10,7 +10,7 @@
       'trackingId': config.trackingId,
       'cookieDomain': config.cookieDomain,
       'cookieExpires': config.expires * 24 * 60 * 60,
-      'cookieFlags': 'Secure; SameSite=Lax',
+      'cookieFlags': 'Secure; SameSite=Strict',
     });
 
     window.ga('set', 'anonymizeIp', config.anonymizeIp);

--- a/app/assets/javascripts/govuk/cookie-functions.js
+++ b/app/assets/javascripts/govuk/cookie-functions.js
@@ -132,7 +132,7 @@
       if (typeof options === 'undefined') {
         options = {};
       }
-      var cookieString = name + '=' + value + '; path=/; SameSite=Lax';
+      var cookieString = name + '=' + value + '; path=/; SameSite=Strict';
       if (options.days) {
         var date = new Date();
         date.setTime(date.getTime() + (options.days * 24 * 60 * 60 * 1000));
@@ -160,4 +160,3 @@
     return null;
   };
 }(window));
-

--- a/app/config.py
+++ b/app/config.py
@@ -63,7 +63,7 @@ class Config(object):
     SESSION_COOKIE_NAME = "emergency_alerts_session"
     SESSION_COOKIE_SECURE = False
     SESSION_PROTECTION = None
-    SESSION_COOKIE_SAMESITE = "Lax"
+    SESSION_COOKIE_SAMESITE = "Strict"
     # don't send back the cookie if it hasn't been modified by the request. this means that the expiry time won't be
     # updated unless the session is changed - but it's generally refreshed by `save_service_or_org_after_request`
     # every time anyway, except for specific endpoints (png/pdfs generally) where we've disabled that handler.

--- a/tests/javascripts/analytics/analytics.test.js
+++ b/tests/javascripts/analytics/analytics.test.js
@@ -49,7 +49,7 @@ describe("Analytics", () => {
       setUpArguments = window.ga.mock.calls;
 
       expect(setUpArguments[0]).toEqual(['create', {
-       'trackingId': 'UA-75215134-1', 'cookieDomain': 'auto', 'cookieExpires': 31536000, "cookieFlags": "Secure; SameSite=Lax",
+       'trackingId': 'UA-75215134-1', 'cookieDomain': 'auto', 'cookieExpires': 31536000, "cookieFlags": "Secure; SameSite=Strict",
       }]);
       expect(setUpArguments[1]).toEqual(['set', 'anonymizeIp', true]);
       expect(setUpArguments[2]).toEqual(['set', 'allowAdFeatures', false]);


### PR DESCRIPTION
As per the guidance in the Pen Test Report, found [here](https://docs.google.com/document/d/1sYq-2rR6QBI4b2iHrgeR6dxAAkbHbLecFhN3r4Crf3g/edit#heading=h.3tbugp1), this PR changes the SameSite directive for the cookie. 