### PR TITLE
EAS-2342 Updating page titles & live-search component labels to describe functionality

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1595,13 +1595,13 @@ class SearchByNameForm(StripWhitespaceForm):
 
 class AdminSearchUsersByEmailForm(StripWhitespaceForm):
     search = GovukSearchField(
-        "Search by name or email address",
+        "Search and filter by name or email address",
         validators=[DataRequired("You need to enter full or partial email address to search by.")],
     )
 
 
 class SearchUsersForm(StripWhitespaceForm):
-    search = GovukSearchField("Search by name or email address")
+    search = GovukSearchField("Search and filter by name or email address")
 
 
 class SearchNotificationsForm(StripWhitespaceForm):
@@ -1625,7 +1625,7 @@ class SearchTemplatesForm(StripWhitespaceForm):
 
     def __init__(self, api_keys, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.search.label.text = "Search by name or ID" if api_keys else "Search by name"
+        self.search.label.text = "Search and filter by name or ID" if api_keys else "Search and filter by name"
 
 
 class PlaceholderForm(StripWhitespaceForm):

--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -6,6 +6,7 @@
 {%- from "partials/notifications/sessionInactivityDialog.html" import sessionInactivityDialog -%}
 {%- from "partials/notifications/sessionExpiryDialog.html" import sessionExpiryDialog -%}
 {% from "components/cookie-banner.html" import cookie_banner %}
+{% from "components/page-title-prefix.html" import page_title_prefix %}
 
 {% block headIcons %}
   <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="{{ asset_url('images/favicon.ico') }}" type="image/x-icon" />
@@ -39,7 +40,7 @@
 {% endblock %}
 
 {% block pageTitle %}
-   {% block per_page_title %}{% endblock %} – GOV.UK Emergency Alerts
+  {{page_title_prefix()}}{% block per_page_title %}{% endblock %} – GOV.UK Emergency Alerts
 {% endblock %}
 
 {% block bodyStart %}

--- a/app/templates/components/page-title-prefix.html
+++ b/app/templates/components/page-title-prefix.html
@@ -10,7 +10,8 @@
                 'remove',
                 'revoke this API key',
                 'stop broadcasting',
-                'info'
+                'info',
+                'default'
             ] %}
                 {% set message = message if message is string else message[0] %}
                 {% if '?' in message %}

--- a/app/templates/components/page-title-prefix.html
+++ b/app/templates/components/page-title-prefix.html
@@ -1,0 +1,24 @@
+{% macro page_title_prefix() %}
+    {% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+        {% for category, message in messages %}
+            {% if category in [
+                'cancel',
+                'delete',
+                'suspend',
+                'resume',
+                'remove',
+                'revoke this API key',
+                'stop broadcasting',
+                'info'
+            ] %}
+                {% set message = message if message is string else message[0] %}
+                {% if '?' in message %}
+                    {% set message = message.split('?')[0] + '?'%}
+                {% endif %}
+                {{ message ~ ' - '}}
+            {% endif %}
+        {% endfor %}
+    {% endif %}
+    {% endwith %}
+{% endmacro %}

--- a/app/templates/views/broadcast/areas-with-sub-areas.html
+++ b/app/templates/views/broadcast/areas-with-sub-areas.html
@@ -19,7 +19,7 @@
     target_selector='.file-list-item',
     show=show_search_form,
     form=search_form,
-    label='Search by name')
+    label='Search and filter by name')
   }}
 
   {% for area in library|sort %}

--- a/app/templates/views/broadcast/areas.html
+++ b/app/templates/views/broadcast/areas.html
@@ -21,7 +21,7 @@
       target_selector='.govuk-checkboxes__item',
       show=show_search_form,
       form=search_form,
-      label='Search by name')
+      label='Search and filter by name')
   }}
 
   {% call form_wrapper() %}

--- a/app/templates/views/broadcast/counties.html
+++ b/app/templates/views/broadcast/counties.html
@@ -23,7 +23,7 @@
     <div class="form-group govuk-!-margin-bottom-4">
       {{ form.select_all }}
     </div>
-    {{ live_search(target_selector='.file-list-item', show=show_search_form, form=search_form, label='Or by district') }}
+    {{ live_search(target_selector='.file-list-item', show=show_search_form, form=search_form, label='Or filter by district') }}
 
     <div class="govuk-!-margin-bottom-6">
     {% for area in county.sub_areas|sort %}

--- a/app/templates/views/broadcast/search-coordinates.html
+++ b/app/templates/views/broadcast/search-coordinates.html
@@ -11,7 +11,11 @@
 {% from "govuk_frontend_jinja/components/error-summary/macro.html" import govukErrorSummary %}
 
 {% block per_page_title %}
-{{ page_title }} – {{ current_service.name }}
+  {% if bleed %}
+    Chosen alert area – {{ current_service.name }}
+  {% else %}
+    {{ page_title }} – {{ current_service.name }}
+  {% endif %}
 {% endblock %}
 
 {% block service_page_title %}
@@ -68,7 +72,11 @@
 
 
 {% block maincolumn_content %}
-{{ page_header('Choose alert area', classes="heading-no-margin-top") }}
+  {% if bleed %}
+    {{ page_header('Chosen alert area', classes="heading-no-margin-top") }}
+  {% else %}
+    {{ page_header(page_title, classes="heading-no-margin-top") }}
+  {% endif %}
 
 {% if form.errors %}
   {{ govukErrorSummary({

--- a/app/templates/views/broadcast/search-postcodes.html
+++ b/app/templates/views/broadcast/search-postcodes.html
@@ -11,7 +11,11 @@
 {% from "components/input-custom-error.html" import inputWithCustomError %}
 
 {% block per_page_title %}
-  {{ page_title }} – {{ current_service.name }}
+  {% if bleed %}
+    Chosen alert area – {{ current_service.name }}
+  {% else %}
+    {{ page_title }} – {{ current_service.name }}
+  {% endif %}
 {% endblock %}
 
 {% block service_page_title %}
@@ -42,7 +46,11 @@
 {% endif %}
 
 {% block maincolumn_content %}
-  {{ page_header('Choose alert area', classes="heading-no-margin-top") }}
+  {% if bleed %}
+    {{ page_header('Chosen alert area', classes="heading-no-margin-top") }}
+  {% else %}
+    {{ page_header(page_title, classes="heading-no-margin-top") }}
+  {% endif %}
   {{ errorSummary(form) }}
   {% call form_wrapper() %}
   <div class="mapping-form">

--- a/app/templates/views/broadcast/sub-areas.html
+++ b/app/templates/views/broadcast/sub-areas.html
@@ -24,7 +24,7 @@
       {{ form.select_all }}
     </div>
 
-    {{ live_search(target_selector='#sub-areas .govuk-checkboxes__item', show=show_search_form, form=search_form, label='Or by electoral ward') }}
+    {{ live_search(target_selector='#sub-areas .govuk-checkboxes__item', show=show_search_form, form=search_form, label='Or filter by electoral ward') }}
 
     <div id="sub-areas">
       {{ form.areas }}

--- a/app/templates/views/edit-user-permissions.html
+++ b/app/templates/views/edit-user-permissions.html
@@ -6,7 +6,11 @@
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
-  {{ user.name or user.email_localpart }}
+  {% if not delete%}
+    {{ user.name or user.email_localpart }}
+  {% else %}
+    {{'Are you sure you want to remove {}?'.format(user.name)}}
+  {% endif %}
 {% endblock %}
 
 {% block backLink %}

--- a/app/templates/views/organisations/add-nhs-local-organisation.html
+++ b/app/templates/views/organisations/add-nhs-local-organisation.html
@@ -25,7 +25,7 @@
       target_selector='.govuk-radios__item',
       show=True,
       form=search_form,
-      label='Search by name',
+      label='Search and filter by name',
       autofocus=True)
     }}
     {{ form.organisations }}

--- a/app/templates/views/organisations/index.html
+++ b/app/templates/views/organisations/index.html
@@ -10,7 +10,7 @@
 
   <h1 class="heading-medium">Organisations</h1>
 
-  {{ live_search(target_selector='.browse-list-item', show=True, form=search_form, label='Search by name') }}
+  {{ live_search(target_selector='.browse-list-item', show=True, form=search_form, label='Search and filter by name') }}
 
   <nav class="browse-list">
     <ul>

--- a/app/templates/views/organisations/organisation/index.html
+++ b/app/templates/views/organisations/organisation/index.html
@@ -57,7 +57,7 @@
         target_selector='.organisation-service',
         show=True,
         form=search_form,
-        label='Search by service'
+        label='Search and filter by service'
       ) }}
     </div>
   {% endif %}

--- a/app/templates/views/platform-admin/search.html
+++ b/app/templates/views/platform-admin/search.html
@@ -5,7 +5,11 @@
 {% from "components/error-summary.html" import errorSummary %}
 
 {% block per_page_title %}
-  Search
+  {% if show_results %}
+    Search results
+  {% else %}
+    Search
+  {% endif %}
 {% endblock %}
 
 {% block platform_admin_content %}

--- a/app/utils/broadcast.py
+++ b/app/utils/broadcast.py
@@ -258,7 +258,7 @@ def render_coordinates_page(
 ):
     return render_template(
         "views/broadcast/search-coordinates.html",
-        page_title="Choose a coordinate area",
+        page_title="Choose alert area",
         broadcast_message=broadcast_message,
         back_link=url_for(
             ".choose_broadcast_area",

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -843,7 +843,7 @@ def test_manage_org_users_should_show_live_search_if_more_than_7_users(
         "govuk-input",
         "govuk-!-width-full",
     ]
-    assert normalize_spaces(page.select_one("label[for=search]").text) == "Search by name or email address"
+    assert normalize_spaces(page.select_one("label[for=search]").text) == "Search and filter by name or email address"
 
 
 def test_edit_organisation_user_shows_the_delete_confirmation_banner(

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -979,6 +979,7 @@ def test_archive_organisation_prompts_user(
     delete_page = client_request.get(
         "main.archive_organisation",
         org_id=organisation_one["id"],
+        _test_page_prefix="Are you sure you want to delete ‘organisation one’?",
     )
     assert normalize_spaces(delete_page.select_one(".banner-dangerous").text) == (
         "Are you sure you want to delete ‘organisation one’? There’s no way to undo this. Yes, delete"

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -2980,7 +2980,11 @@ def test_archive_service_prompts_user(
     service_one["restricted"] = is_trial_service
     client_request.login(user)
 
-    settings_page = client_request.get("main.archive_service", service_id=SERVICE_ONE_ID, _test_page_title=False)
+    settings_page = client_request.get(
+        "main.archive_service",
+        service_id=SERVICE_ONE_ID,
+        _test_page_prefix="Are you sure you want to delete ‘service one’?",
+    )
     delete_link = settings_page.select(".page-footer-link a")[0]
     assert normalize_spaces(delete_link.text) == "Delete this service"
     assert delete_link["href"] == url_for(
@@ -2988,7 +2992,11 @@ def test_archive_service_prompts_user(
         service_id=SERVICE_ONE_ID,
     )
 
-    delete_page = client_request.get("main.archive_service", service_id=SERVICE_ONE_ID, _test_page_title=False)
+    delete_page = client_request.get(
+        "main.archive_service",
+        service_id=SERVICE_ONE_ID,
+        _test_page_prefix="Are you sure you want to delete ‘service one’?",
+    )
     assert normalize_spaces(delete_page.select_one(".banner-dangerous").text) == (
         "Are you sure you want to delete ‘service one’? There’s no way to undo this. Yes, delete"
     )

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -2980,7 +2980,7 @@ def test_archive_service_prompts_user(
     service_one["restricted"] = is_trial_service
     client_request.login(user)
 
-    settings_page = client_request.get("main.archive_service", service_id=SERVICE_ONE_ID)
+    settings_page = client_request.get("main.archive_service", service_id=SERVICE_ONE_ID, _test_page_title=False)
     delete_link = settings_page.select(".page-footer-link a")[0]
     assert normalize_spaces(delete_link.text) == "Delete this service"
     assert delete_link["href"] == url_for(
@@ -2988,10 +2988,7 @@ def test_archive_service_prompts_user(
         service_id=SERVICE_ONE_ID,
     )
 
-    delete_page = client_request.get(
-        "main.archive_service",
-        service_id=SERVICE_ONE_ID,
-    )
+    delete_page = client_request.get("main.archive_service", service_id=SERVICE_ONE_ID, _test_page_title=False)
     assert normalize_spaces(delete_page.select_one(".banner-dangerous").text) == (
         "Are you sure you want to delete ‘service one’? There’s no way to undo this. Yes, delete"
     )

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -4189,6 +4189,7 @@ def test_cancel_broadcast(
         ".cancel_broadcast_message",
         service_id=SERVICE_ONE_ID,
         broadcast_message_id=fake_uuid,
+        _test_page_prefix="Are you sure you want to stop this broadcast now?",
     )
     assert normalize_spaces(page.select_one(".banner-dangerous").text) == (
         "Are you sure you want to stop this broadcast now? Yes, stop broadcasting"

--- a/tests/app/main/views/test_find_users.py
+++ b/tests/app/main/views/test_find_users.py
@@ -214,7 +214,11 @@ def test_archive_user_prompts_for_confirmation(
     mock_get_organisations_and_services_for_user,
 ):
     client_request.login(platform_admin_user)
-    page = client_request.get("main.archive_user", user_id=api_user_active["id"])
+    page = client_request.get(
+        "main.archive_user",
+        user_id=api_user_active["id"],
+        _test_page_prefix="There's no way to reverse this! Are you sure you want to archive this user?",
+    )
 
     assert "Are you sure you want to archive this user?" in page.select_one("div.banner-dangerous").text
 

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -238,7 +238,7 @@ def test_should_show_live_search_if_more_than_7_users(
         "govuk-input",
         "govuk-!-width-full",
     ]
-    assert normalize_spaces(page.select_one("label[for=search]").text) == "Search by name or email address"
+    assert normalize_spaces(page.select_one("label[for=search]").text) == "Search and filter by name or email address"
 
 
 def test_should_show_caseworker_on_overview_page(

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -1938,7 +1938,11 @@ def test_edit_user_permissions_with_delete_query_shows_banner(
     client_request, active_user_with_permissions, mock_get_users_by_service, mock_get_template_folders, service_one
 ):
     page = client_request.get(
-        "main.edit_user_permissions", service_id=service_one["id"], user_id=active_user_with_permissions["id"], delete=1
+        "main.edit_user_permissions",
+        service_id=service_one["id"],
+        user_id=active_user_with_permissions["id"],
+        delete=1,
+        _test_page_prefix="Are you sure you want to remove Test User?",
     )
 
     banner = page.select_one("div.banner-dangerous")

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -834,6 +834,7 @@ def test_show_cancel_letter_confirmation(
         "main.cancel_letter",
         service_id=SERVICE_ONE_ID,
         notification_id=fake_uuid,
+        _test_page_prefix="Are you sure you want to cancel sending this letter?",
     )
 
     flash_message = normalize_spaces(page.select_one("div.banner-dangerous").text)

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -311,7 +311,7 @@ def test_should_show_live_search_if_list_of_templates_taller_than_screen(
 
     assert search["data-notify-module"] == "live-search"
     assert search["data-targets"] == "#template-list .template-list-item"
-    assert normalize_spaces(search.select_one("label").text) == "Search by name"
+    assert normalize_spaces(search.select_one("label").text) == "Search and filter by name"
 
     assert len(page.select(search["data-targets"])) == len(page.select("#template-list .govuk-label")) == 14
 
@@ -326,7 +326,7 @@ def test_should_label_search_by_id_for_services_with_api_keys(
         "main.choose_template",
         service_id=SERVICE_ONE_ID,
     )
-    assert normalize_spaces(page.select_one(".live-search label").text) == "Search by name or ID"
+    assert normalize_spaces(page.select_one(".live-search label").text) == "Search and filter by name or ID"
 
 
 def test_should_show_live_search_if_service_has_lots_of_folders(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2162,6 +2162,7 @@ def client_request(_logged_in_client, mocker, service_one):  # noqa (C901 too co
             _follow_redirects=False,
             _expected_redirect=None,
             _test_page_title=True,
+            _test_page_prefix=None,
             _test_for_elements_without_class=True,
             _optional_args="",
             **endpoint_kwargs,
@@ -2172,6 +2173,7 @@ def client_request(_logged_in_client, mocker, service_one):  # noqa (C901 too co
                 _follow_redirects=_follow_redirects,
                 _expected_redirect=_expected_redirect,
                 _test_page_title=_test_page_title,
+                _test_page_prefix=_test_page_prefix,
                 _test_for_elements_without_class=_test_for_elements_without_class,
             )
 
@@ -2182,6 +2184,7 @@ def client_request(_logged_in_client, mocker, service_one):  # noqa (C901 too co
             _follow_redirects=False,
             _expected_redirect=None,
             _test_page_title=True,
+            _test_page_prefix=None,
             _test_for_elements_without_class=True,
             **endpoint_kwargs,
         ):
@@ -2202,11 +2205,18 @@ def client_request(_logged_in_client, mocker, service_one):  # noqa (C901 too co
 
             if _test_page_title:
                 # Page should have one H1
-                assert len(page.select("h1")) == 1
-                page_title, h1 = (normalize_spaces(page.select_one(selector).text) for selector in ("title", "h1"))
-                assert normalize_spaces(page_title).startswith(
-                    h1
-                ), f"Page {url} title '{page_title}' does not start with H1 '{h1}'"
+                if _test_page_prefix:
+                    assert len(page.select("h1")) == 1
+                    page_title, h1 = (normalize_spaces(page.select_one(selector).text) for selector in ("title", "h1"))
+                    assert normalize_spaces(page_title).startswith(
+                        f"{_test_page_prefix} - {h1}"
+                    ), f"Page {url} title '{page_title}' does not start with prefix & H1 '{_test_page_prefix} - {h1}'"
+                else:
+                    assert len(page.select("h1")) == 1
+                    page_title, h1 = (normalize_spaces(page.select_one(selector).text) for selector in ("title", "h1"))
+                    assert normalize_spaces(page_title).startswith(
+                        h1
+                    ), f"Page {url} title '{page_title}' does not start with H1 '{h1}'"
 
             if _test_for_elements_without_class and _expected_status not in (301, 302):
                 for tag, hint in (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2206,11 +2206,10 @@ def client_request(_logged_in_client, mocker, service_one):  # noqa (C901 too co
             if _test_page_title:
                 # Page should have one H1
                 if _test_page_prefix:
-                    assert len(page.select("h1")) == 1
-                    page_title, h1 = (normalize_spaces(page.select_one(selector).text) for selector in ("title", "h1"))
+                    page_title = normalize_spaces(page.select_one("title").text)
                     assert normalize_spaces(page_title).startswith(
-                        f"{_test_page_prefix} - {h1}"
-                    ), f"Page {url} title '{page_title}' does not start with prefix & H1 '{_test_page_prefix} - {h1}'"
+                        f"{_test_page_prefix}"
+                    ), f"Page {url} title '{page_title}' does not start with prefix '{_test_page_prefix}'"
                 else:
                     assert len(page.select("h1")) == 1
                     page_title, h1 = (normalize_spaces(page.select_one(selector).text) for selector in ("title", "h1"))

--- a/tests/javascripts/liveSearch.test.js
+++ b/tests/javascripts/liveSearch.test.js
@@ -472,7 +472,7 @@ describe('Live search', () => {
 
   describe("With a list of content items", () => {
 
-    searchLabelText = "Search by name or email address";
+    searchLabelText = "Search and filter by name or email address";
 
     function getContentItems (users) {
 


### PR DESCRIPTION
This PR includes:
- Changing page title & h1 text for map pages when area is displayed on map
- Changing page title & h1 text for Platform Admin search when results displayed
- Added page title prefix component that uses the banner message
- Page title prefix component added to admin_template to ensure whenever banner message, for certain categories, is displayed then page title is prefixed with that message
- Tests adjusted accordingly