### PR TITLE
DAC report remediations (EAS-2345, EAS-2346, EAS-2336)

### DIFF
--- a/app/assets/stylesheets/_app.scss
+++ b/app/assets/stylesheets/_app.scss
@@ -254,3 +254,7 @@ details .arrow {
   margin-left: auto;
   margin-right: govuk-spacing(1);
 }
+
+.service-block {
+  padding-bottom: 16px;
+}

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2192,12 +2192,19 @@ class EastingNorthingCoordinatesForm(StripWhitespaceForm):
 
 class ChooseCoordinateTypeForm(StripWhitespaceForm):
     content = GovukRadiosField(
+        "Choose coordinate type",
         choices=[
             ("latitude_longitude", "Latitude and longitude"),
             ("easting_northing", "Eastings and northings"),
         ],
         param_extensions={
-            "fieldset": {"legend": {"classes": "govuk-visually-hidden"}},
+            "fieldset": {
+                "legend": {
+                    "text": "Choose coordinate type",
+                    "isPageHeading": True,
+                    "classes": "govuk-fieldset__legend--l",
+                }
+            },
             "hint": {"text": "Select one option"},
             "items": [
                 {"hint": {"text": "For example, 51.503630, -0.126770"}},

--- a/app/templates/views/broadcast/choose-coordinates-type.html
+++ b/app/templates/views/broadcast/choose-coordinates-type.html
@@ -2,7 +2,6 @@
 {% from "components/banner.html" import banner_wrapper %}
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
-{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "views/broadcast/macros/area-map.html" import map %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
@@ -20,19 +19,9 @@
 {% endblock %}
 
 {% block maincolumn_content %}
-{{ page_header("Choose coordinate type") }}
   {% call form_wrapper() %}
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-    {{ form.content(
-        param_extensions={
-          'fieldset': {
-            'legend': {
-              'isPageHeading': True,
-              'classes': 'govuk-fieldset__legend--l'
-            }
-          }
-        }
-      ) }}
+    {{ form.content() }}
       {{ page_footer('Continue') }}
   {% endcall %}
 

--- a/app/templates/views/broadcast/partials/dashboard-table.html
+++ b/app/templates/views/broadcast/partials/dashboard-table.html
@@ -8,7 +8,7 @@
       <h2>
         <a class="file-list-filename-large govuk-link govuk-link--no-visited-state" href="{{ url_for(view_broadcast_endpoint, service_id=current_service.id, broadcast_message_id=item.id) }}">{{ item.template.name }}</a>
       </h2>
-      <span class="file-list-hint-large govuk-!-margin-bottom-2" tabindex="0">
+      <span class="file-list-hint-large govuk-!-margin-bottom-2">
         {{ item.content }}
       </span>
       {% if item.status == 'pending-approval' %}

--- a/app/templates/views/platform-admin/services.html
+++ b/app/templates/views/platform-admin/services.html
@@ -1,37 +1,8 @@
 {% extends "views/platform-admin/_base_template.html" %}
-{% from "components/page-footer.html" import page_footer %}
-{% from "components/big-number.html" import big_number, big_number_with_status %}
-{% from "components/table.html" import mapping_table, field, stats_fields, row_group, row, right_aligned_field_heading, hidden_field_heading, text_field %}
-{% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
-{% from "govuk_frontend_jinja/components/details/macro.html" import govukDetails %}
-
-{% macro services_table(services, caption) %}
-  {% call(item, row_number) mapping_table(
-    caption=caption,
-    caption_visible=False,
-    field_headings_visible=False,
-  ) %}
-
-    {% for service in services %}
-
-      {% call row_group() %}
-
-        {% call row() %}
-          {% call field(border=False, colspan=3) %}
-            <a href="{{ url_for('main.service_dashboard', service_id=service['id']) }}" class="file-list-filename-large govuk-link govuk-link--no-visited-state govuk-!-padding-bottom-4 govuk-!-padding-top-4">{{ service['name'] }}</a>
-            {% if not service['active'] %}
-              <span class="heading-medium hint">&ensp;Archived</span>
-            {% endif %}
-          {% endcall %}
-        {% endcall %}
-      {% endcall %}
-
-    {% endfor %}
-
-  {% endcall %}
-{% endmacro %}
-
+{% from "components/page-footer.html" import page_footer %}
+{% from "components/big-number.html" import big_number_with_status %}
+{% from "components/form.html" import form_wrapper %}
 
 {% block per_page_title %}
   {{ page_title|capitalize }}
@@ -42,7 +13,22 @@
   <h1 class="heading-medium">
     {{ page_title|capitalize }}
   </h1>
-
-  {{ services_table(services, page_title|capitalize) }}
-
+  <div class="keyline-block"></div>
+  <nav class="browse-list">
+    {% for service in services %}
+      <div class="govuk-grid-row service-block">
+        <div class="govuk-grid-column-full">
+          <li class="browse-list-item">
+            <a href="{{ url_for('main.service_dashboard', service_id=service['id']) }}" class="govuk-link govuk-link--no-visited-state">
+              {{ service['name'] }}
+            </a>
+            {% if not service['active'] %}
+              <p class="browse-list-hint">Archived</p>
+            {% endif %}
+          </li>
+        </div>
+      </div>
+      <div class="keyline-block"></div>
+    {% endfor %}
+  </nav>
 {% endblock %}

--- a/tests/app/main/views/test_platform_admin.py
+++ b/tests/app/main/views/test_platform_admin.py
@@ -226,12 +226,12 @@ def test_should_show_archived_services_last(
         {"detailed": True, "include_from_test_key": True, "only_active": ANY}
     )
 
-    table_body = page.select_one("table tbody")
-    services = [service.tr for service in table_body.select("tbody")]
+    list_body = page.select_one("nav.browse-list")
+    services = list(list_body.select("li.browse-list-item"))
     assert len(services) == 3
-    assert normalize_spaces(services[0].td.text) == "A"
-    assert normalize_spaces(services[1].td.text) == "B"
-    assert normalize_spaces(services[2].td.text) == "C Archived"
+    assert normalize_spaces(services[0].text) == "A"
+    assert normalize_spaces(services[1].text) == "B"
+    assert normalize_spaces(services[2].text) == "C Archived"
 
 
 @pytest.mark.parametrize(
@@ -271,11 +271,12 @@ def test_should_order_services_by_usage_with_inactive_last(
         {"detailed": True, "include_from_test_key": True, "only_active": ANY}
     )
 
-    services = page.select("table tbody tbody tr:first-child")
+    list_body = page.select_one("nav.browse-list")
+    services = list(list_body.select("li.browse-list-item"))
     assert len(services) == 3
-    assert normalize_spaces(services[0].td.text) == "My Service 2"
-    assert normalize_spaces(services[1].td.text) == "My Service 1"
-    assert normalize_spaces(services[2].td.text) == "My Service 3 Archived"
+    assert normalize_spaces(services[0].text) == "My Service 2"
+    assert normalize_spaces(services[1].text) == "My Service 1"
+    assert normalize_spaces(services[2].text) == "My Service 3 Archived"
 
 
 def test_sum_service_usage_is_sum_of_all_activity(fake_uuid):


### PR DESCRIPTION
This PR includes the following changes, made as part of DAC report suggestions:

- Tab index removed from alerts displayed on 'Current Alerts' page as was selectable and shouldn't have been (Issue ID: DAC_Focus_order_01)
- Legend added to ChooseCoordinateType form group as legend element previously missing (Issue ID: DAC_Ungrouped_content_01)
- Table containing list of live services changed into a list of live services (Issue ID: DAC_Tables_01)
- Tests adjusted accordingly with elements updated