### PR TITLE
EAS-2366 Persist invitation ID when not in session state

### DIFF
--- a/app/main/views/invites.py
+++ b/app/main/views/invites.py
@@ -78,7 +78,7 @@ def accept_invite(token):
                     return redirect(url_for("main.broadcast_tour", service_id=service.id, step_index=1))
             return redirect(url_for("main.service_dashboard", service_id=service.id))
     else:
-        return redirect(url_for("main.register_from_invite"))
+        return redirect(url_for("main.register_from_invite", token=token))
 
 
 @main.route("/organisation-invitation/<token>")

--- a/app/main/views/register.py
+++ b/app/main/views/register.py
@@ -16,6 +16,7 @@ def register_from_invite():
         token = request.args.get("token")
         if token is not None:
             invited_user = InvitedUser.from_token(token)
+            session["invited_user_id"] = invited_user.id
 
     if not invited_user:
         abort(404)

--- a/app/main/views/register.py
+++ b/app/main/views/register.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta
 
-from flask import abort, redirect, render_template, session, url_for
+from flask import abort, redirect, render_template, request, session, url_for
 
 from app.main import main
 from app.main.forms import RegisterUserFromInviteForm, RegisterUserFromOrgInviteForm
@@ -11,6 +11,12 @@ from app.models.user import InvitedOrgUser, InvitedUser, User
 @main.route("/register-from-invite", methods=["GET", "POST"])
 def register_from_invite():
     invited_user = InvitedUser.from_session()
+
+    if not invited_user:
+        token = request.args.get("token")
+        if token is not None:
+            invited_user = InvitedUser.from_token(token)
+
     if not invited_user:
         abort(404)
 

--- a/tests/app/main/views/test_accept_invite.py
+++ b/tests/app/main/views/test_accept_invite.py
@@ -374,7 +374,7 @@ def test_new_user_accept_invite_calls_api_and_redirects_to_registration(
     client_request.get(
         "main.accept_invite",
         token="thisisnotarealtoken",
-        _expected_redirect="/register-from-invite",
+        _expected_redirect="/register-from-invite?token=thisisnotarealtoken",
     )
 
     mock_check_invite_token.assert_called_with("thisisnotarealtoken")
@@ -502,7 +502,7 @@ def test_new_user_accept_invite_completes_new_registration_redirects_to_verify(
     mocker,
 ):
     client_request.logout()
-    expected_redirect_location = "/register-from-invite"
+    expected_redirect_location = "/register-from-invite?token=thisisnotarealtoken"
 
     client_request.get(
         "main.accept_invite",
@@ -625,7 +625,7 @@ def test_new_invited_user_verifies_and_added_to_service(
     client_request.get(
         "main.accept_invite",
         token="thisisnotarealtoken",
-        _expected_redirect=url_for("main.register_from_invite"),
+        _expected_redirect=url_for("main.register_from_invite", token="thisisnotarealtoken"),
     )
 
     # get redirected to register from invite


### PR DESCRIPTION
- Pass through invitation token so that it's available under 'strict' session cookie handling