### PR TITLE
EAS-2374 Ensure timeout warning modal is displayed once only

### DIFF
--- a/app/assets/javascripts/timeout.js
+++ b/app/assets/javascripts/timeout.js
@@ -103,8 +103,9 @@ let sessionExpiryTimeout;
   };
 
   const displaySessionExpiryDialog = function(inactivityDialog, sessionExpiryDialog) {
+    let timeUntilDialogDisplay = getTimeLeftUntilExpiryDialogDisplayed();
     // displays session expiry popup after timeout
-    if (isLoggedIn()) {
+    if (isLoggedIn() && timeUntilDialogDisplay > 0) {
       inactivityLogoutTimeout = setTimeout(function () {
         if (sessionExpiryDialog)
         {
@@ -117,7 +118,7 @@ let sessionExpiryTimeout;
           clearTimeout(inactivityLogoutTimeout);
           clearTimeout(lastActiveTimeout);
         }
-      }, getTimeLeftUntilExpiryDialogDisplayed());
+      }, timeUntilDialogDisplay);
     }
   };
 


### PR DESCRIPTION
Warning should not be displayed once it has been acknowledged, or the user signs out. So just check the "time until warning is displayed" time and don't show the dialog if that interval has passed.