### PR TITLE
EAS-2567: Don't use scientific notation for long eastings/northings

### DIFF
--- a/app/formatters.py
+++ b/app/formatters.py
@@ -1,6 +1,7 @@
 import re
 import unicodedata
 from datetime import datetime, timedelta, timezone
+from decimal import Decimal
 from functools import lru_cache
 from math import floor, log10
 from numbers import Number
@@ -308,3 +309,16 @@ def format_auth_type(auth_type, with_indefinite_article=False):
         return f"{indefinite_article} {auth_type.lower()}"
 
     return auth_type
+
+
+def format_number_no_scientific(num):
+    """
+    Returns a string of the number similar to ':g' formatting (e.g. no trailing zeroes), but this will *not* be in
+    scientific notation after the number reaches a certain threshold.
+    """
+    dec = Decimal(str(num))
+    # Ensure whole numbers with trailing zeroes are not normlaized to exponent format
+    # See https://docs.python.org/3.9/library/decimal.html#decimal-faq
+    normalised = dec.quantize(Decimal(1)) if dec == dec.to_integral() else dec.normalize()
+
+    return str(normalised)

--- a/app/utils/broadcast.py
+++ b/app/utils/broadcast.py
@@ -6,7 +6,7 @@ from shapely.geometry import MultiPolygon, Polygon
 from shapely.ops import unary_union
 
 from app.broadcast_areas.models import CustomBroadcastArea, CustomBroadcastAreas
-from app.formatters import round_to_significant_figures
+from app.formatters import format_number_no_scientific, round_to_significant_figures
 from app.main.forms import (
     EastingNorthingCoordinatesForm,
     LatitudeLongitudeCoordinatesForm,
@@ -16,13 +16,13 @@ from app.models.broadcast_message import BroadcastMessage
 
 
 def create_coordinate_area_slug(coordinate_type, first_coordinate, second_coordinate, radius):
-    radius_min_sig_figs = "{:g}".format(radius)
+    radius_min_sig_figs = format_number_no_scientific(radius)
     id = f"{radius_min_sig_figs}km around "
     if coordinate_type == "latitude_longitude":
         id = f"{id}{first_coordinate} latitude, {second_coordinate} longitude"
     elif coordinate_type == "easting_northing":
-        first_coordinate = "{:g}".format((first_coordinate))
-        second_coordinate = "{:g}".format(second_coordinate)
+        first_coordinate = format_number_no_scientific(first_coordinate)
+        second_coordinate = format_number_no_scientific(second_coordinate)
         id = f"{id}the easting of {first_coordinate} and the northing of {second_coordinate}"
     return id
 

--- a/tests/app/utils/test_broadcast.py
+++ b/tests/app/utils/test_broadcast.py
@@ -41,6 +41,7 @@ from tests.app.broadcast_areas.custom_polygons import (
         ("latitude_longitude", 54, -2, 12),
         ("easting_northing", 530111, 170000, 12),
         ("easting_northing", 530111, 179963, 1),
+        ("easting_northing", 341216, 1006204.592, 23),  # EAS-2567: Long values end up as scientific notation
     ],
 )
 def test_create_coordinate_area_slug(coordinate_type, first_coordinate, second_coordinate, radius):


### PR DESCRIPTION
As title, longer values are no longer converted to scientific notation by Python's general number formatting. Unfortunately there doesn't seem to be an easy way to opt out of that behaviour and it's assumed the trimming of decimals is desireable. The Decimal class provides a bit of a workaround though.

I did use the same values to create a test on the JavaScript side (`customMapping.test.js`) but this didn't seem to be affected.

I'm not sure if there's a desire to round decimals to a certain length (do we have limits?) but that can certainly be done.