### PR TITLE
Adjusts hint text on rejected alerts page

### DIFF
--- a/app/templates/views/broadcast/previous-broadcasts.html
+++ b/app/templates/views/broadcast/previous-broadcasts.html
@@ -10,9 +10,9 @@
 {% block maincolumn_content %}
 
   <h1 class="heading-medium">{{ page_title }}</h1>
-  {% if page_title == "Rejected alerts" %}
+    {% if page_title == "Rejected alerts" %}
       <p class="govuk-body">
-        Alerts rejected for broadcast that may be edited and resubmitted for approval
+        Alerts rejected for broadcast cannot be edited and resubmitted for approval
       </p>
     {% endif %}
 


### PR DESCRIPTION
This PR changes the text on 'Rejected alerts' page as users cannot currently edit or re-submit alerts.