### PR TITLE
EAS-2576 Extend maximum session timeout

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -71,7 +71,7 @@ class Config(object):
     BROADCAST_ORGANISATION_ID = "38e4bf69-93b0-445d-acee-53ea53fe02df"
 
     INACTIVITY_MINS = 28
-    EXPIRY_WARNING_MINS = 58
+    EXPIRY_WARNING_MINS = (5 * 60) + 58  # 5 hours, 58 minutes
     INACTIVITY_WARNING_DURATION = 2
 
     ADMIN_ACTION_ALLOW_SELF_APPROVAL = os.environ.get("ADMIN_ACTION_ALLOW_SELF_APPROVAL", "false").lower() == "true"

--- a/app/config.py
+++ b/app/config.py
@@ -44,7 +44,7 @@ class Config(object):
     HTTP_PROTOCOL = "http"
     EAS_APP_NAME = "admin"
     NOTIFY_LOG_LEVEL = "DEBUG"
-    PERMANENT_SESSION_LIFETIME = 60 * 60  # 60 minutes - maximum duration for a session
+    PERMANENT_SESSION_LIFETIME = 60 * 60 * 6  # 6 hours - maximum duration for a session
     SESSION_COOKIE_HTTPONLY = True
     SESSION_COOKIE_NAME = "emergency_alerts_session"
     SESSION_COOKIE_SECURE = False

--- a/app/templates/views/signin.html
+++ b/app/templates/views/signin.html
@@ -20,7 +20,7 @@
       {% if status == 'expired' %}
         <h1 class="heading-large">You’ve been signed out</h1>
         <p class="govuk-body">
-          We do this every hour to keep your information secure. Sign back in to start a new session.
+          We do this every 6 hours to keep your information secure. Sign back in to start a new session.
         </p>
       {% elif status == 'inactive' %}
         <h1 class="heading-large">You’ve been signed out due to inactivity</h1>


### PR DESCRIPTION
This PR includes:

- Adjustment to the `PERMANENT_SESSION_LIFETIME`, to ensure sessions now have lifetime of 6 hours
- Adjustment to `EXPIRY_WARNING_MINS` to ensure the dialog to warn them 2 minutes before their session expires, appears 5 hours and 58 mins after session began
- Adjustment to text on page user is redirected to when session expires, that now says "every 6 hours" instead of "every hour"