### PR TITLE
Extends PIP_DEFAULT_TIMEOUT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,8 @@ install-node: install-nvm
 ## DEVELOPMENT
 .PHONY: bootstrap
 bootstrap: generate-version-file install-node ## Set up everything to run the app
-	${PYTHON_EXECUTABLE_PREFIX}pip3 install -r requirements_local_utils.txt
+	export PIP_DEFAULT_TIMEOUT=100
+	. ${PYTHON_EXECUTABLE_PREFIX}pip3 install -r requirements_local_utils.txt
 	. ~/.nvm-source && npm ci --no-audit
 	. ~/.nvm-source && npm run build
 	. environment.sh; ./scripts/get-broadcast-areas-db.sh ./app/broadcast_areas $(BUCKET_NAME)


### PR DESCRIPTION
This PR includes the fix for a recurring issue within my hosted development environment, that could be an issue elsewhere. `make bootstrap` was failing because pip was timing out searching for versions of various packages.