### PR TITLE
EAS-2624: Dynamically change invite/edit user submit button based upon sensitive permissions

### DIFF
--- a/app/assets/javascripts/permissionFormButtons.js
+++ b/app/assets/javascripts/permissionFormButtons.js
@@ -1,0 +1,31 @@
+(function (Modules) {
+  "use strict";
+
+  // PermissionFormButtons will dynamically adjust the submit button text if sensitive permissions are added.
+  // It expects to be given a parent <form> element, and will note those with "data-permission-sensitive".
+  Modules.PermissionFormButtons = function () {
+    this.start = function (permissionForm) {
+      var $permissionForm = $(permissionForm)
+      var submitButton = $permissionForm.find(":submit");
+      var initialSubmitButtonText = submitButton.text();
+
+      var sensitivePermissionCheckboxes = $("[data-permission-sensitive]");
+      var sensitivePermissionValues = sensitivePermissionCheckboxes.map(function () { return this.value }).get();
+
+      // Note the form's initial state for editing a user
+      var initialPermissions = $("#permissions_field input:checked").map(function () { return this.value }).get();
+
+      sensitivePermissionCheckboxes.on("change", function () {
+        var currentPermissions = $("#permissions_field input:checked").map(function () { return this.value }).get();
+        var newPermissions = currentPermissions.filter(function (permission) { return !initialPermissions.includes(permission) })
+
+        if (newPermissions.some(function (permission) { return sensitivePermissionValues.includes(permission) })) {
+          submitButton.text("Submit for approval");
+        } else {
+          submitButton.text(initialSubmitButtonText);
+        }
+      })
+    };
+  };
+
+})(window.GOVUK.NotifyModules);

--- a/app/assets/javascripts/permissionFormSubmitButton.js
+++ b/app/assets/javascripts/permissionFormSubmitButton.js
@@ -1,9 +1,9 @@
 (function (Modules) {
   "use strict";
 
-  // PermissionFormButtons will dynamically adjust the submit button text if sensitive permissions are added.
+  // PermissionFormSubmitButton will dynamically adjust the submit button text if sensitive permissions are added.
   // It expects to be given a parent <form> element, and will note those with "data-permission-sensitive".
-  Modules.PermissionFormButtons = function () {
+  Modules.PermissionFormSubmitButton = function () {
     this.start = function (permissionForm) {
       var $permissionForm = $(permissionForm)
       var submitButton = $permissionForm.find(":submit");

--- a/app/assets/javascripts/permissionFormSubmitButton.js
+++ b/app/assets/javascripts/permissionFormSubmitButton.js
@@ -5,26 +5,26 @@
   // It expects to be given a parent <form> element, and will note those with "data-permission-sensitive".
   Modules.PermissionFormSubmitButton = function () {
     this.start = function (permissionForm) {
-      var $permissionForm = $(permissionForm)
+      var $permissionForm = $(permissionForm);
       var submitButton = $permissionForm.find(":submit");
       var initialSubmitButtonText = submitButton.text();
 
       var sensitivePermissionCheckboxes = $("[data-permission-sensitive]");
-      var sensitivePermissionValues = sensitivePermissionCheckboxes.map(function () { return this.value }).get();
+      var sensitivePermissionValues = sensitivePermissionCheckboxes.map(function () { return this.value; }).get();
 
       // Note the form's initial state for editing a user
-      var initialPermissions = $("#permissions_field input:checked").map(function () { return this.value }).get();
+      var initialPermissions = $("#permissions_field input:checked").map(function () { return this.value; }).get();
 
       sensitivePermissionCheckboxes.on("change", function () {
-        var currentPermissions = $("#permissions_field input:checked").map(function () { return this.value }).get();
-        var newPermissions = currentPermissions.filter(function (permission) { return !initialPermissions.includes(permission) })
+        var currentPermissions = $("#permissions_field input:checked").map(function () { return this.value; }).get();
+        var newPermissions = currentPermissions.filter(function (permission) { return !initialPermissions.includes(permission); });
 
-        if (newPermissions.some(function (permission) { return sensitivePermissionValues.includes(permission) })) {
+        if (newPermissions.some(function (permission) { return sensitivePermissionValues.includes(permission); })) {
           submitButton.text("Submit for approval");
         } else {
           submitButton.text(initialSubmitButtonText);
         }
-      })
+      });
     };
   };
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -5,6 +5,7 @@ from itertools import chain
 from numbers import Number
 
 import pytz
+from emergency_alerts_utils.admin_action import ADMIN_SENSITIVE_PERMISSIONS
 from emergency_alerts_utils.formatters import strip_all_whitespace
 from emergency_alerts_utils.insensitive_dict import InsensitiveDict
 from emergency_alerts_utils.validation import InvalidPhoneError, validate_phone_number
@@ -570,6 +571,15 @@ class GovukCheckboxesFieldWithNetworkRequired(GovukCheckboxesField):
     validators = [DataRequired("Select a mobile network")]
 
 
+class GovukCheckboxesFieldWithSensitivePermissionAttribute(GovukCheckboxesField):
+    def get_item_from_option(self, option):
+        item = super().get_item_from_option(option)
+        item["attributes"] = (
+            {"data-permission-sensitive": "true"} if item["value"] in ADMIN_SENSITIVE_PERMISSIONS else {}
+        )
+        return item
+
+
 # Wraps checkboxes rendering in HTML needed by the collapsible JS
 class GovukCollapsibleCheckboxesField(GovukCheckboxesField):
     param_extensions = {"hint": {"html": '<div class="selection-summary" role="region" aria-live="polite"></div>'}}
@@ -819,7 +829,7 @@ class PermissionsForm(BasePermissionsForm):
 
 
 class BroadcastPermissionsForm(BasePermissionsForm):
-    permissions_field = GovukCheckboxesField(
+    permissions_field = GovukCheckboxesFieldWithSensitivePermissionAttribute(
         "Permissions",
         choices=[(value, label) for value, label in broadcast_permission_options],
         filters=[filter_by_broadcast_permissions],
@@ -827,7 +837,7 @@ class BroadcastPermissionsForm(BasePermissionsForm):
             "hint": {
                 "text": "Team members who can create or approve alerts can also reject them."
                 + " Platform admin approval is required to enable creating or approving alerts."
-            }
+            },
         },
     )
 

--- a/app/templates/components/page-footer.html
+++ b/app/templates/components/page-footer.html
@@ -13,7 +13,8 @@
   centered_button=False,
   button_url=None,
   search=False,
-  classes=""
+  classes="",
+  button_attributes={}
 ) %}
   <div class="page-footer {{ classes }}">
     {% if button_text %}
@@ -40,6 +41,7 @@
         }) %}
       {% endif %}
 
+      {% set _ = button_data.update({"attributes": button_attributes}) %}
       {{ govukButton(button_data) }}
 
     {% endif %}

--- a/app/templates/views/api/keys/create.html
+++ b/app/templates/views/api/keys/create.html
@@ -26,7 +26,7 @@
   {% call form_wrapper() %}
     {{ form.key_name }}
     {{ form.key_type }}
-    {{ page_footer('Continue', button_name='continue') }}
+    {{ page_footer('Submit for approval', button_name='continue') }}
   {% endcall %}
 
 {% endblock %}

--- a/app/templates/views/edit-user-permissions.html
+++ b/app/templates/views/edit-user-permissions.html
@@ -43,7 +43,7 @@
       </a>
     </p>
   {% endif %}
-  {% call form_wrapper() %}
+  {% call form_wrapper(module="permission-form-buttons") %}
 
     {% include 'views/manage-users/permissions.html' %}
 

--- a/app/templates/views/edit-user-permissions.html
+++ b/app/templates/views/edit-user-permissions.html
@@ -50,7 +50,8 @@
     {{ page_footer(
       'Save',
       delete_link=url_for('.edit_user_permissions', service_id=current_service.id, user_id=user.id, delete='yes'),
-      delete_link_text='Remove this team member'
+      delete_link_text='Remove this team member',
+      button_attributes={"aria-live": "polite"}
     ) }}
 
   {% endcall %}

--- a/app/templates/views/edit-user-permissions.html
+++ b/app/templates/views/edit-user-permissions.html
@@ -43,7 +43,7 @@
       </a>
     </p>
   {% endif %}
-  {% call form_wrapper(module="permission-form-buttons") %}
+  {% call form_wrapper(module="permission-form-submit-button") %}
 
     {% include 'views/manage-users/permissions.html' %}
 

--- a/app/templates/views/invite-user.html
+++ b/app/templates/views/invite-user.html
@@ -16,7 +16,7 @@
 
   {{ page_header('Invite {}'.format(user_to_invite.name if user_to_invite else 'a team member')) }}
 
-  {% call form_wrapper(module="permission-form-buttons") %}
+  {% call form_wrapper(module="permission-form-submit-button") %}
 
     {% if user_to_invite %}
       <p class="govuk-body">

--- a/app/templates/views/invite-user.html
+++ b/app/templates/views/invite-user.html
@@ -16,7 +16,7 @@
 
   {{ page_header('Invite {}'.format(user_to_invite.name if user_to_invite else 'a team member')) }}
 
-  {% call form_wrapper() %}
+  {% call form_wrapper(module="permission-form-buttons") %}
 
     {% if user_to_invite %}
       <p class="govuk-body">

--- a/app/templates/views/invite-user.html
+++ b/app/templates/views/invite-user.html
@@ -33,7 +33,10 @@
 
     {% include 'views/manage-users/permissions.html' %}
 
-    {{ page_footer('Send invitation email') }}
+    {{ page_footer(
+      'Send invitation email',
+      button_attributes={"aria-live": "polite"}
+    ) }}
 
   {% endcall %}
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -144,6 +144,7 @@ const javascripts = () => {
     paths.src + 'javascripts/main.js',
     paths.src + 'javascripts/timeout.js',
     paths.src + 'javascripts/exclusiveCheckbox.js',
+    paths.src + 'javascripts/permissionFormButtons.js',
   ])
   .pipe(plugins.prettyerror())
   .pipe(plugins.babel({

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -146,10 +146,10 @@ const javascripts = () => {
     paths.src + 'javascripts/exclusiveCheckbox.js',
     paths.src + 'javascripts/permissionFormSubmitButton.js',
   ])
-    .pipe(plugins.prettyerror())
-    .pipe(plugins.babel({
-      presets: ['@babel/preset-env']
-    }));
+  .pipe(plugins.prettyerror())
+  .pipe(plugins.babel({
+    presets: ['@babel/preset-env']
+  }));
 
   // return single stream of all vinyl objects piped from the end of the vendored stream, then
   // those from the end of the local stream
@@ -162,10 +162,10 @@ const javascripts = () => {
 
 const sass = () => {
   return src([
-    paths.src + '/stylesheets/main*.scss',
-    paths.src + '/stylesheets/map.scss',
-    paths.src + '/stylesheets/print.scss'
-  ])
+      paths.src + '/stylesheets/main*.scss',
+      paths.src + '/stylesheets/map.scss',
+      paths.src + '/stylesheets/print.scss'
+    ])
     .pipe(plugins.prettyerror())
     .pipe(plugins.sass.sync({
       includePaths: [
@@ -183,9 +183,9 @@ const sass = () => {
 
 const images = () => {
   return src([
-    paths.src + 'images/**/*',
-    paths.govuk_frontend + 'govuk/assets/images/**/*'
-  ])
+      paths.src + 'images/**/*',
+      paths.govuk_frontend + 'govuk/assets/images/**/*'
+    ])
     .pipe(dest(paths.dist + 'images/'))
 };
 
@@ -213,10 +213,10 @@ const watchFiles = {
 const lint = {
   'sass': () => {
     return src([
-      paths.src + 'stylesheets/*.scss',
-      paths.src + 'stylesheets/components/*.scss',
-      paths.src + 'stylesheets/views/*.scss',
-    ])
+        paths.src + 'stylesheets/*.scss',
+        paths.src + 'stylesheets/components/*.scss',
+        paths.src + 'stylesheets/views/*.scss',
+      ])
       .pipe(plugins.sassLint({
         'options': { 'formatter': 'stylish' },
         'rules': { 'mixins-before-declarations': [2, { 'exclude': ['media', 'govuk-media-query'] } ] }
@@ -226,8 +226,8 @@ const lint = {
   },
   'js': (cb) => {
     return src(
-      paths.src + 'javascripts/**/*.js'
-    )
+        paths.src + 'javascripts/**/*.js'
+      )
       .pipe(plugins.jshint())
       .pipe(plugins.jshint.reporter(stylish))
       .pipe(plugins.jshint.reporter('fail'))

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -144,12 +144,12 @@ const javascripts = () => {
     paths.src + 'javascripts/main.js',
     paths.src + 'javascripts/timeout.js',
     paths.src + 'javascripts/exclusiveCheckbox.js',
-    paths.src + 'javascripts/permissionFormButtons.js',
+    paths.src + 'javascripts/permissionFormSubmitButton.js',
   ])
-  .pipe(plugins.prettyerror())
-  .pipe(plugins.babel({
-    presets: ['@babel/preset-env']
-  }));
+    .pipe(plugins.prettyerror())
+    .pipe(plugins.babel({
+      presets: ['@babel/preset-env']
+    }));
 
   // return single stream of all vinyl objects piped from the end of the vendored stream, then
   // those from the end of the local stream
@@ -162,10 +162,10 @@ const javascripts = () => {
 
 const sass = () => {
   return src([
-      paths.src + '/stylesheets/main*.scss',
-      paths.src + '/stylesheets/map.scss',
-      paths.src + '/stylesheets/print.scss'
-    ])
+    paths.src + '/stylesheets/main*.scss',
+    paths.src + '/stylesheets/map.scss',
+    paths.src + '/stylesheets/print.scss'
+  ])
     .pipe(plugins.prettyerror())
     .pipe(plugins.sass.sync({
       includePaths: [
@@ -183,9 +183,9 @@ const sass = () => {
 
 const images = () => {
   return src([
-      paths.src + 'images/**/*',
-      paths.govuk_frontend + 'govuk/assets/images/**/*'
-    ])
+    paths.src + 'images/**/*',
+    paths.govuk_frontend + 'govuk/assets/images/**/*'
+  ])
     .pipe(dest(paths.dist + 'images/'))
 };
 
@@ -213,10 +213,10 @@ const watchFiles = {
 const lint = {
   'sass': () => {
     return src([
-        paths.src + 'stylesheets/*.scss',
-        paths.src + 'stylesheets/components/*.scss',
-        paths.src + 'stylesheets/views/*.scss',
-      ])
+      paths.src + 'stylesheets/*.scss',
+      paths.src + 'stylesheets/components/*.scss',
+      paths.src + 'stylesheets/views/*.scss',
+    ])
       .pipe(plugins.sassLint({
         'options': { 'formatter': 'stylish' },
         'rules': { 'mixins-before-declarations': [2, { 'exclude': ['media', 'govuk-media-query'] } ] }
@@ -226,8 +226,8 @@ const lint = {
   },
   'js': (cb) => {
     return src(
-        paths.src + 'javascripts/**/*.js'
-      )
+      paths.src + 'javascripts/**/*.js'
+    )
       .pipe(plugins.jshint())
       .pipe(plugins.jshint.reporter(stylish))
       .pipe(plugins.jshint.reporter('fail'))

--- a/tests/javascripts/permissionFormSubmitButton.test.js
+++ b/tests/javascripts/permissionFormSubmitButton.test.js
@@ -1,0 +1,148 @@
+const helpers = require('./support/helpers.js');
+
+beforeAll(() => {
+  require('../../app/assets/javascripts/permissionFormSubmitButton.js');
+});
+
+afterAll(() => {
+  require('./support/teardown.js');
+});
+
+describe('Permission form dynamic submit button text', () => {
+  let submitButton;
+
+  beforeEach(() => {
+
+    // set up DOM
+    document.body.innerHTML = `
+      <form
+        method="post"
+        autocomplete="off"
+        data-notify-module="permission-form-submit-button"
+        novalidate=""
+      >
+        <div class="govuk-form-group">
+          <fieldset
+            class="govuk-fieldset"
+            id="permissions_field"
+          >
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+              Permissions
+            </legend>
+
+            <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+              <div class="govuk-checkboxes__item">
+                <input
+                  class="govuk-checkboxes__input"
+                  id="permissions_field-0"
+                  name="permissions_field"
+                  type="checkbox"
+                  value="manage_templates"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="permissions_field-0"
+                >
+                  Add and edit templates
+                </label>
+              </div>
+
+              <div class="govuk-checkboxes__item">
+                <input
+                  class="govuk-checkboxes__input"
+                  id="permissions_field-1"
+                  name="permissions_field"
+                  type="checkbox"
+                  value="create_broadcasts"
+                  data-permission-sensitive="true"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="permissions_field-1"
+                >
+                  Create new alerts
+                </label>
+              </div>
+
+              <div class="govuk-checkboxes__item">
+                <input
+                  class="govuk-checkboxes__input"
+                  id="permissions_field-2"
+                  name="permissions_field"
+                  type="checkbox"
+                  value="approve_broadcasts"
+                  data-permission-sensitive="true"
+                />
+                <label
+                  class="govuk-label govuk-checkboxes__label"
+                  for="permissions_field-2"
+                >
+                  Approve alerts
+                </label>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+
+        <div class="page-footer">
+          <button
+            id="submit-button"
+            type="submit"
+            class="govuk-button page-footer__button"
+            data-module="govuk-button"
+          >Save</button>
+        </div>
+      </form>`;
+
+    submitButton = document.getElementById("submit-button");
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  describe("When the page loads", () => {
+    test("The submit button should have its initial text value", () => {
+      window.GOVUK.notifyModules.start();
+      expect(submitButton.textContent).toBe("Save");
+    });
+  });
+
+  describe("Checkbox change events", () => {
+    test("The submit button changes to approval when a sensitive permission is checked", () => {
+      window.GOVUK.notifyModules.start();
+      expect(submitButton.textContent).toBe("Save");
+
+      // create_broadcasts
+      document.getElementById("permissions_field-1").click();
+      expect(submitButton.textContent).toBe("Submit for approval");
+
+      // Uncheck again
+      document.getElementById("permissions_field-1").click();
+      expect(submitButton.textContent).toBe("Save");
+    });
+
+    test("The submit button does not change when a sensitive permission is unchecked", () => {
+      document.getElementById("permissions_field-1").click(); // Checked initially
+
+      window.GOVUK.notifyModules.start();
+      expect(submitButton.textContent).toBe("Save");
+
+      // create_broadcasts
+      document.getElementById("permissions_field-1").click(); // Uncheck
+      expect(submitButton.textContent).toBe("Save");
+    });
+
+    test("The submit button does not change when an unsensitive permission is unchecked", () => {
+
+      window.GOVUK.notifyModules.start();
+      expect(submitButton.textContent).toBe("Save");
+
+      // manage_templates
+      document.getElementById("permissions_field-0").click();
+      expect(submitButton.textContent).toBe("Save");
+    });
+  });
+
+
+});

--- a/tests/javascripts/permissionFormSubmitButton.test.js
+++ b/tests/javascripts/permissionFormSubmitButton.test.js
@@ -133,7 +133,7 @@ describe('Permission form dynamic submit button text', () => {
       expect(submitButton.textContent).toBe("Save");
     });
 
-    test("The submit button does not change when an unsensitive permission is unchecked", () => {
+    test("The submit button does not change when an unsensitive permission is checked", () => {
 
       window.GOVUK.notifyModules.start();
       expect(submitButton.textContent).toBe("Save");


### PR DESCRIPTION
This introduces a new small JavaScript module that will attach itself to the permissions form and dynamically edit the submit button's text on the fly if a 'sensitive' permission is added.

It took me a little while to decipher how the JavaScript module system works internally but I think I've matched the approach with the existing patterns! This uses the existing constants derived from utils so any future permissions should naturally link up.

We can start with an existing permission:
<img width="761" alt="image" src="https://github.com/user-attachments/assets/2884baaa-286c-48e9-8eb6-e4181df5afc1" />

And add a new sensitive one:
<img width="743" alt="image" src="https://github.com/user-attachments/assets/3002270e-c1e5-4f72-87be-aded9b1ecaa7" />

Or remove the existing sensitive one:
<img width="730" alt="image" src="https://github.com/user-attachments/assets/a4d52f28-e480-453e-a342-867f63e616e4" />

