### PR TITLE
EAS-2620 Reorder alerts

### DIFF
--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -110,6 +110,7 @@ def broadcast_dashboard_previous(service_id):
         page_title="Past alerts",
         empty_message="You do not have any past alerts",
         view_broadcast_endpoint=".view_previous_broadcast",
+        reverse_chronological_sort=True,
     )
 
 
@@ -125,6 +126,7 @@ def broadcast_dashboard_rejected(service_id):
         page_title="Rejected alerts",
         empty_message="You do not have any rejected alerts",
         view_broadcast_endpoint=".view_rejected_broadcast",
+        reverse_chronological_sort=True,
     )
 
 
@@ -143,6 +145,7 @@ def get_broadcast_dashboard_partials(service_id):
             broadcasts=broadcast_messages.with_status("pending-approval", "broadcasting", "draft"),
             empty_message="You do not have any current alerts",
             view_broadcast_endpoint=".view_current_broadcast",
+            reverse_chronological_sort=False,  # Keep order that API returns - by status then alphabetically
         ),
     )
 

--- a/app/templates/views/broadcast/partials/dashboard-table.html
+++ b/app/templates/views/broadcast/partials/dashboard-table.html
@@ -1,7 +1,7 @@
 {% from "components/table.html" import list_table, field, right_aligned_field_heading, row_heading %}
 {% from "govuk_frontend_jinja/components/tag/macro.html" import govukTag %}
 
-{% set sorted_broadcasts = broadcasts|list|sort|reverse if chronological_sort else broadcasts|list %}
+{% set sorted_broadcasts = broadcasts|list|sort|reverse if reverse_chronological_sort else broadcasts|list %}
 
 <div class="ajax-block-container js-mark-focus-on-parent" data-classes-to-persist="js-child-has-focus">
 {% for item in sorted_broadcasts %}

--- a/app/templates/views/broadcast/partials/dashboard-table.html
+++ b/app/templates/views/broadcast/partials/dashboard-table.html
@@ -1,8 +1,10 @@
 {% from "components/table.html" import list_table, field, right_aligned_field_heading, row_heading %}
 {% from "govuk_frontend_jinja/components/tag/macro.html" import govukTag %}
 
+{% set sorted_broadcasts = broadcasts|list|sort|reverse if chronological_sort else broadcasts|list %}
+
 <div class="ajax-block-container js-mark-focus-on-parent" data-classes-to-persist="js-child-has-focus">
-{% for item in broadcasts|list %}
+{% for item in sorted_broadcasts %}
   <div class="keyline-block">
     <div class="file-list file-list--sectioned govuk-!-margin-bottom-2">
       <h2>


### PR DESCRIPTION
This PR ensures that past alerts and rejected alerts displayed in reverse chronological order, but order of alerts on 'Current alerts' page remains the same.