### PR TITLE
EAS-2637: Admin: Run `make freeze-requirements` to remove unused items

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -21,6 +21,7 @@ pwdpy==1.0.1
 
 itsdangerous==2.1.2
 govuk-frontend-jinja==3.3.0
+govuk-bank-holidays==0.11
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains
 prometheus-client==0.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,6 @@
 #
 #    pip-compile requirements.in
 #
-ago==0.0.95
-    # via -r requirements.in
 attrs==22.2.0
     # via
     #   flake8-bugbear
@@ -32,8 +30,6 @@ certifi==2022.12.7
     #   requests
 cffi==1.15.1
     # via cryptography
-chardet==5.0.0
-    # via pyexcel
 charset-normalizer==2.1.1
     # via requests
 click==8.1.3
@@ -46,8 +42,6 @@ cryptography==38.0.3
     #   moto
 docopt==0.6.2
     # via notifications-python-client
-et-xmlfile==1.1.0
-    # via openpyxl
 exceptiongroup==1.1.1
     # via pytest
 execnet==1.9.0
@@ -77,8 +71,6 @@ freezegun==1.2.2
     # via -r requirements.in
 gds-metrics @ git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72
     # via -r requirements.in
-govuk-bank-holidays==0.11
-    # via -r requirements.in
 govuk-frontend-jinja==3.3.0
     # via -r requirements.in
 humanize==4.4.0
@@ -106,14 +98,6 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-lml==0.1.0
-    # via
-    #   pyexcel
-    #   pyexcel-io
-lxml==4.9.1
-    # via
-    #   pyexcel-ezodf
-    #   pyexcel-ods3
 markupsafe==2.1.5
     # via
     #   -r requirements.in
@@ -128,8 +112,6 @@ mypy-extensions==1.0.0
     # via black
 notifications-python-client==8.0.0
     # via -r requirements.in
-openpyxl==3.0.10
-    # via pyexcel-xlsx
 packaging==23.0
     # via
     #   black
@@ -154,23 +136,6 @@ pycodestyle==2.11.1
     #   flake8-print
 pycparser==2.21
     # via cffi
-pyexcel==0.7.0
-    # via -r requirements.in
-pyexcel-ezodf==0.3.4
-    # via pyexcel-ods3
-pyexcel-io==0.6.6
-    # via
-    #   -r requirements.in
-    #   pyexcel
-    #   pyexcel-ods3
-    #   pyexcel-xls
-    #   pyexcel-xlsx
-pyexcel-ods3==0.6.1
-    # via -r requirements.in
-pyexcel-xls==0.7.0
-    # via -r requirements.in
-pyexcel-xlsx==0.6.0
-    # via -r requirements.in
 pyflakes==3.2.0
     # via flake8
 pyjwt==2.4.0
@@ -200,7 +165,6 @@ pyyaml==6.0.1
     # via responses
 requests==2.28.1
     # via
-    #   govuk-bank-holidays
     #   moto
     #   notifications-python-client
     #   requests-mock
@@ -219,8 +183,6 @@ six==1.16.0
     #   requests-mock
 soupsieve==2.4
     # via beautifulsoup4
-texttable==1.6.4
-    # via pyexcel
 tomli==2.0.1
     # via
     #   black
@@ -244,10 +206,6 @@ wtforms==3.1.2
     # via
     #   -r requirements.in
     #   flask-wtf
-xlrd==2.0.1
-    # via pyexcel-xls
-xlwt==1.3.0
-    # via pyexcel-xls
 xmltodict==0.13.0
     # via moto
 zipp==3.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -71,6 +71,8 @@ freezegun==1.2.2
     # via -r requirements.in
 gds-metrics @ git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72
     # via -r requirements.in
+govuk-bank-holidays==0.11
+    # via -r requirements.in
 govuk-frontend-jinja==3.3.0
     # via -r requirements.in
 humanize==4.4.0
@@ -165,6 +167,7 @@ pyyaml==6.0.1
     # via responses
 requests==2.28.1
     # via
+    #   govuk-bank-holidays
     #   moto
     #   notifications-python-client
     #   requests-mock


### PR DESCRIPTION
https://github.com/alphagov/emergency-alerts-admin/pull/214 removed many dependencies but seemed to miss a step in fully regenerating the `requirements.txt` at some point.

As part of https://github.com/alphagov/emergency-alerts-utils/pull/100 we will bring in `lxml` as a transitive dependency again but at a slightly newer version which would currently conflict during the build process. There is no code in admin (currently) that would call `lxml` anyway.

I honestly have no idea what most of these dependencies do and whether we call them...

(Edit: we did need `govuk-bank-holidays`, but I think we should bump that version)