### PR TITLE
Remove edit link if user cannot edit

### DIFF
--- a/app/templates/components/alert-summary-list.html
+++ b/app/templates/components/alert-summary-list.html
@@ -64,13 +64,13 @@
         {% set conditional_action_text %}
             Change
         {% endset %}
-        {% set conditional_duration_action_text %}
-            {%- if broadcast_message.duration -%}
-                Change
-            {%- else -%}
-                Add duration
-            {% endif %}
-        {% endset%}
+
+        {% if broadcast_message.duration %}
+            {% set conditional_duration_action_text = "Change" %}
+            {% set visually_hidden_duration_text = " duration" %}
+        {% else %}
+            {% set conditional_duration_action_text = "Add duration" %}
+        {% endif %}
 
         {% if broadcast_message.areas %}
             {% set conditional_area_action_text = "Change" %}
@@ -170,7 +170,7 @@
                 {
                     'href': url_for(".choose_broadcast_duration", service_id=service_id, broadcast_message_id=broadcast_message.id,),
                     'text': conditional_duration_action_text,
-                    'visuallyHiddenText': "duration"
+                    'visuallyHiddenText': visually_hidden_duration_text
                 }
                 ] if display_action else []
             }

--- a/app/templates/components/alert-summary-list.html
+++ b/app/templates/components/alert-summary-list.html
@@ -59,31 +59,27 @@
         {% endif %}
     {% endset %}
 
-    {% set conditional_area_action_text %}
-        {% if broadcast_message.status == "draft" and current_user.has_permissions('create_broadcasts', restrict_admin_usage=True) %}
+    {% if broadcast_message.status == "draft" and current_user.has_permissions('create_broadcasts', restrict_admin_usage=True) %}
+        {% set display_action = True %}
+        {% set conditional_action_text %}
+            Change
+        {% endset %}
+        {% set conditional_duration_action_text %}
+            {% if broadcast_message.duration %}
+                Change
+            {% else %}
+                Add duration
+            {% endif %}
+        {% endset%}
+        {% set conditional_area_action_text %}
             {% if broadcast_message.areas %}
                 Change
             {% else %}
                 Add area
             {% endif%}
-        {% endif %}
-    {% endset %}
+        {% endset %}
+    {% endif %}
 
-    {% set conditional_duration_action_text %}
-        {% if broadcast_message.status == "draft" and current_user.has_permissions('create_broadcasts', restrict_admin_usage=True) %}
-            {% if broadcast_message.duration %}
-                Change
-            {% else %}
-                Add duration
-            {% endif%}
-        {% endif %}
-    {% endset %}
-
-    {% set conditional_action_text %}
-        {% if broadcast_message.status == "draft" and current_user.has_permissions('create_broadcasts', restrict_admin_usage=True)%}
-            Change
-        {% endif %}
-    {% endset %}
 
     {% set count_of_phones_html %}
         <p class="govuk-body">
@@ -124,7 +120,7 @@
                 'text': conditional_action_text,
                 'visuallyHiddenText': "reference"
             }
-            ]
+            ] if display_action else []
         }
         },
         {
@@ -139,9 +135,9 @@
             {
                 'href': url_for('.edit_broadcast', service_id=service_id, broadcast_message_id=broadcast_message.id),
                 'text': conditional_action_text,
-                'visuallyHiddenText': "message"
+                'visuallyHiddenText': "message",
             }
-            ]
+            ] if display_action else []
         }
         },
         {
@@ -158,7 +154,7 @@
                 'text': conditional_area_action_text,
                 'visuallyHiddenText': "areas"
             }
-            ]
+            ] if display_action else []
         }
         },
         {
@@ -175,7 +171,7 @@
                     'text': conditional_duration_action_text,
                     'visuallyHiddenText': "duration"
                 }
-                ]
+                ] if display_action else []
             }
             }
         ] %}

--- a/app/templates/components/alert-summary-list.html
+++ b/app/templates/components/alert-summary-list.html
@@ -65,19 +65,20 @@
             Change
         {% endset %}
         {% set conditional_duration_action_text %}
-            {% if broadcast_message.duration %}
+            {%- if broadcast_message.duration -%}
                 Change
-            {% else %}
+            {%- else -%}
                 Add duration
             {% endif %}
         {% endset%}
-        {% set conditional_area_action_text %}
-            {% if broadcast_message.areas %}
-                Change
-            {% else %}
-                Add area
-            {% endif%}
-        {% endset %}
+
+        {% if broadcast_message.areas %}
+            {% set conditional_area_action_text = "Change" %}
+            {% set visually_hidden_area_text = " areas" %}
+        {% else %}
+            {% set conditional_area_action_text = "Add area" %}
+        {% endif %}
+
     {% endif %}
 
 
@@ -152,7 +153,7 @@
             {
                 'href': conditional_area_action_link,
                 'text': conditional_area_action_text,
-                'visuallyHiddenText': "areas"
+                'visuallyHiddenText': visually_hidden_area_text
             }
             ] if display_action else []
         }

--- a/app/templates/views/broadcast/partials/area-map-javascripts.html
+++ b/app/templates/views/broadcast/partials/area-map-javascripts.html
@@ -38,43 +38,45 @@
 
 
   let mapElement = document.getElementById('area-list-map');
-  const grandparent = mapElement.parentNode.parentNode;
-  const isInDetails = grandparent.className.indexOf('govuk-details') !== -1;
-  let details;
+  if (mapElement != null) {
+    const grandparent = mapElement.parentNode.parentNode;
+    const isInDetails = grandparent.className.indexOf('govuk-details') !== -1;
+    let details;
 
-  // if element is inside a details element then to make the map render correctly we open the details element
-  // and set up the map before closing the details map after
-  if (isInDetails) {
-    details = grandparent;
-    details.open = true;
-  }
-
-  mapElement.style.height = Math.max(320, window.innerHeight - mapElement.offsetTop - 100) + 'px';
-
-  const mymap = L.map(
-    'area-list-map',
-    {
-      scrollWheelZoom: false
+    // if element is inside a details element then to make the map render correctly we open the details element
+    // and set up the map before closing the details map after
+    if (isInDetails) {
+      details = grandparent;
+      details.open = true;
     }
-  )
 
-  mymap.setView(
-    [55.378052, -3.435973],
-    5
-  );
-  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-    attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-  }).addTo(mymap);
+    mapElement.style.height = Math.max(320, window.innerHeight - mapElement.offsetTop - 100) + 'px';
 
-  let polygonGroup = L.featureGroup(polygons).addTo(mymap);
-  mymap.fitBounds(
-    polygonGroup.getBounds(),
-    {padding: [1, 1]}
-  );
+    const mymap = L.map(
+      'area-list-map',
+      {
+        scrollWheelZoom: false
+      }
+    )
 
-  // if element is inside a details element then close the details element
-  if (isInDetails) {
-    details.open = false;
+    mymap.setView(
+      [55.378052, -3.435973],
+      5
+    );
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+    }).addTo(mymap);
+
+    let polygonGroup = L.featureGroup(polygons).addTo(mymap);
+    mymap.fitBounds(
+      polygonGroup.getBounds(),
+      {padding: [1, 1]}
+    );
+
+    // if element is inside a details element then close the details element
+    if (isInDetails) {
+      details.open = false;
+    }
   }
 
 </script>

--- a/app/templates/views/broadcast/partials/enlarged-map-javascripts.html
+++ b/app/templates/views/broadcast/partials/enlarged-map-javascripts.html
@@ -59,24 +59,26 @@
     attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
   }).addTo(enlargedMap);
 
-  let polygonGroup2 = L.featureGroup(enlarged_polygons).addTo(enlargedMap);
-  enlargedMap.fitBounds(
-    polygonGroup2.getBounds(),
-    {padding: [0.5, 0.5]}
-  );
-
-  enlargeMapButton.addEventListener("click", function () {
-    enlargedMapModal.showModal();
-    enlargedMap.invalidateSize();
+  if (enlarged_polygons.length > 0) {
+    let polygonGroup2 = L.featureGroup(enlarged_polygons).addTo(enlargedMap);
     enlargedMap.fitBounds(
-    polygonGroup2.getBounds(),
-    {padding: [1, 1]}
+      polygonGroup2.getBounds(),
+      {padding: [0.5, 0.5]}
     );
-    enlargedMapModal.focus();
-  });
 
-  closeMapButton.addEventListener("click", function () {
-    enlargedMapModal.close();
-  });
+    enlargeMapButton.addEventListener("click", function () {
+      enlargedMapModal.showModal();
+      enlargedMap.invalidateSize();
+      enlargedMap.fitBounds(
+      polygonGroup2.getBounds(),
+      {padding: [1, 1]}
+      );
+      enlargedMapModal.focus();
+    });
+
+    closeMapButton.addEventListener("click", function () {
+      enlargedMapModal.close();
+    });
+  }
 
 </script>


### PR DESCRIPTION
This PR remediates an issue where if there's no allowed actions for user, the link element still exists, just without text for [GOVUK Summary list component](https://design-system.service.gov.uk/components/summary-list/).
Additionally, some errors appearing in console, when alert area hasn't been set, have been fixed by only initialising some functionality if area exists.