### PR TITLE
EAS-2604: Implement a geoJSON download link

### DIFF
--- a/app/broadcast_areas/models.py
+++ b/app/broadcast_areas/models.py
@@ -26,12 +26,12 @@ class GetItemByIdMixin:
 class BaseBroadcastArea(ABC):
     @property
     @abstractmethod
-    def simple_polygons(self):
+    def simple_polygons(self) -> Polygons:
         pass
 
     @property
     @abstractmethod
-    def polygons(self):
+    def polygons(self) -> Polygons:
         pass
 
     @property
@@ -40,7 +40,7 @@ class BaseBroadcastArea(ABC):
         pass
 
     @cached_property
-    def simple_polygons_with_bleed(self):
+    def simple_polygons_with_bleed(self) -> Polygons:
         return self.simple_polygons.bleed_by(self.estimated_bleed_in_m)
 
     @cached_property

--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -1223,6 +1223,7 @@ def get_broadcast_geojson(service_id, broadcast_message_id):
                 "type": "Feature",
                 "geometry": {
                     "type": "Polygon",
+                    # geoJSON spec uses WGS84: https://datatracker.ietf.org/doc/html/rfc7946#section-4
                     "coordinates": area.polygons.as_wgs84_coordinates,
                 },
                 "properties": {"name": area.__dict__.get("name")},

--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -1207,7 +1207,7 @@ def view_broadcast_versions(service_id, broadcast_message_id):
 
 
 @main.route("/services/<uuid:service_id>/broadcast/<uuid:broadcast_message_id>/geojson", methods=["GET"])
-@service_has_permission("broadcast")
+@user_has_permissions()
 def get_broadcast_geojson(service_id, broadcast_message_id):
     broadcast_message = BroadcastMessage.from_id(
         broadcast_message_id,

--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -1,9 +1,21 @@
+import json
+from typing import Collection
+
 from emergency_alerts_utils.template import BroadcastPreviewTemplate
-from flask import abort, flash, jsonify, redirect, render_template, request, url_for
+from flask import (
+    Response,
+    abort,
+    flash,
+    jsonify,
+    redirect,
+    render_template,
+    request,
+    url_for,
+)
 from notifications_python_client.errors import HTTPError
 
 from app import current_service
-from app.broadcast_areas.models import CustomBroadcastAreas
+from app.broadcast_areas.models import BaseBroadcastArea, CustomBroadcastAreas
 from app.main import main
 from app.main.forms import (
     BroadcastAreaForm,
@@ -875,9 +887,11 @@ def preview_broadcast_message(service_id, broadcast_message_id):
                 label=create_map_label(areas),
                 areas_string=stringify_areas(areas),
                 broadcast_message_version_count=broadcast_message.get_count_of_versions(),
-                last_updated_time=broadcast_message.get_latest_version().get("created_at")
-                if broadcast_message.get_latest_version()
-                else None,
+                last_updated_time=(
+                    broadcast_message.get_latest_version().get("created_at")
+                    if broadcast_message.get_latest_version()
+                    else None
+                ),
             )
         broadcast_message.request_approval()
         return redirect(
@@ -895,9 +909,9 @@ def preview_broadcast_message(service_id, broadcast_message_id):
         label=create_map_label(areas),
         areas_string=stringify_areas(areas),
         broadcast_message_version_count=broadcast_message.get_count_of_versions(),
-        last_updated_time=broadcast_message.get_latest_version().get("created_at")
-        if broadcast_message.get_latest_version()
-        else None,
+        last_updated_time=(
+            broadcast_message.get_latest_version().get("created_at") if broadcast_message.get_latest_version() else None
+        ),
     )
 
 
@@ -996,9 +1010,11 @@ def approve_broadcast_message(service_id, broadcast_message_id):
             label=create_map_label(areas),
             areas_string=stringify_areas(areas),
             broadcast_message_version_count=broadcast_message.get_count_of_versions(),
-            last_updated_time=broadcast_message.get_latest_version().get("created_at")
-            if broadcast_message.get_latest_version()
-            else None,
+            last_updated_time=(
+                broadcast_message.get_latest_version().get("created_at")
+                if broadcast_message.get_latest_version()
+                else None
+            ),
         )
 
     if broadcast_message.status != "pending-approval":
@@ -1187,4 +1203,36 @@ def view_broadcast_versions(service_id, broadcast_message_id):
             broadcast_message_id=broadcast_message.id,
         ),
         is_edited=len(versions) > 1,
+    )
+
+
+@main.route("/services/<uuid:service_id>/broadcast/<uuid:broadcast_message_id>/geojson", methods=["GET"])
+@service_has_permission("broadcast")
+def get_broadcast_geojson(service_id, broadcast_message_id):
+    broadcast_message = BroadcastMessage.from_id(
+        broadcast_message_id,
+        service_id=service_id,
+    )
+
+    areas: Collection[BaseBroadcastArea] = broadcast_message.areas
+
+    geojson = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": area.polygons.as_wgs84_coordinates,
+                },
+                "properties": {"name": area.__dict__.get("name")},
+            }
+            for area in areas
+        ],
+    }
+
+    return Response(
+        json.dumps(geojson),
+        mimetype="application/geo+json",
+        headers={"Content-Disposition": f"attachment;filename={broadcast_message.reference}.geojson"},
     )

--- a/app/templates/components/alert-summary-list.html
+++ b/app/templates/components/alert-summary-list.html
@@ -193,6 +193,26 @@
             ] %}
     {% endif %}
 
+    {% set download_section_html %}
+        <a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline" href="{{ url_for(
+            ".get_broadcast_geojson",
+            service_id=service_id,
+            broadcast_message_id=broadcast_message.id,
+        ) }}">
+            <span class="govuk-visually-hidden">Download </span>geoJSON
+        </a>
+    {% endset %}
+    {% set summaryListItems = summaryListItems + [
+        {
+        'key': {
+            'text': "Downloads"
+        },
+        'value': {
+            'html': download_section_html
+        },
+        }
+    ] %}
+
     {{ govukSummaryList({
     'rows': summaryListItems
     }) }}

--- a/app/templates/views/broadcast/view-message.html
+++ b/app/templates/views/broadcast/view-message.html
@@ -264,11 +264,25 @@
   {% else %}
     {{ page_header(broadcast_message.template.name) }}
 
-  {{broadcast_details(broadcast_message, current_service)}}
+    {{broadcast_details(broadcast_message, current_service)}}
   {% endif %}
 
   {{alertSummaryList(current_user, current_service.id, broadcast_message, areas, broadcast_message.simple_polygons_with_bleed.estimated_area, broadcast_message.count_of_phones, broadcast_message.count_of_phones_likely, is_custom_broadcast)}}
 
+<!-- TODO: How to make this pretty... -->
+<nav aria-label="Download menu" class="navigation">
+  <ul>
+    <li class="govuk-header__navigation-item">
+      <a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline" href="{{ url_for(
+        ".get_broadcast_geojson",
+        service_id=current_service.id,
+        broadcast_message_id=broadcast_message.id,
+      ) }}">
+        geoJSON
+      </a>
+    </li>
+  </ul>
+</nav>
 
 {% if broadcast_message.status != 'pending-approval' %}
   <p class="govuk-body govuk-!-margin-bottom-3">

--- a/app/templates/views/broadcast/view-message.html
+++ b/app/templates/views/broadcast/view-message.html
@@ -269,21 +269,6 @@
 
   {{alertSummaryList(current_user, current_service.id, broadcast_message, areas, broadcast_message.simple_polygons_with_bleed.estimated_area, broadcast_message.count_of_phones, broadcast_message.count_of_phones_likely, is_custom_broadcast)}}
 
-<!-- TODO: How to make this pretty... -->
-<nav aria-label="Download menu" class="navigation">
-  <ul>
-    <li class="govuk-header__navigation-item">
-      <a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline" href="{{ url_for(
-        ".get_broadcast_geojson",
-        service_id=current_service.id,
-        broadcast_message_id=broadcast_message.id,
-      ) }}">
-        geoJSON
-      </a>
-    </li>
-  </ul>
-</nav>
-
 {% if broadcast_message.status != 'pending-approval' %}
   <p class="govuk-body govuk-!-margin-bottom-3">
     {% if broadcast_message.created_by %}

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -3308,6 +3308,24 @@ def test_preview_broadcast_message_page(
 
     assert normalize_spaces(page.select_one(".broadcast-message-wrapper").text) == "Emergency alert This is a test"
 
+    assert [normalize_spaces(p.text) for p in page.select(".govuk-summary-list__key")] == [
+        "Reference",
+        "Alert message",
+        "Area",
+        "Alert duration",
+        "Phone estimate",
+        "Downloads",
+    ]
+    assert [normalize_spaces(p.text) for p in page.select(".govuk-summary-list__value")] == [
+        "Example template",
+        "Emergency alert Hello",
+        "England Scotland Use the arrow keys to move the map. "
+        + "Use the buttons to zoom the map in or out View larger map",
+        "3 hours",
+        "40,000,000 phones estimated",
+        "Download geoJSON",
+    ]
+
     form = page.select_one("form")
     assert form["method"] == "post"
     assert "action" not in form
@@ -5486,6 +5504,7 @@ def test_view_draft_broadcast_message_page(
         "Area",
         "Alert duration",
         "Phone estimate",
+        "Downloads",
     ]
     assert [normalize_spaces(p.text) for p in page.select(".govuk-summary-list__value")] == [
         "Example template",
@@ -5494,4 +5513,9 @@ def test_view_draft_broadcast_message_page(
         + "Use the buttons to zoom the map in or out View larger map",
         "3 hours",
         "40,000,000 phones estimated",
+        "Download geoJSON",
     ]
+
+
+def test_can_get_geojson():
+    pass

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -3318,10 +3318,10 @@ def test_preview_broadcast_message_page(
     ]
     assert [normalize_spaces(p.text) for p in page.select(".govuk-summary-list__value")] == [
         "Example template",
-        "Emergency alert Hello",
+        "Emergency alert This is a test",
         "England Scotland Use the arrow keys to move the map. "
         + "Use the buttons to zoom the map in or out View larger map",
-        "3 hours",
+        "",
         "40,000,000 phones estimated",
         "Download geoJSON",
     ]
@@ -5539,6 +5539,7 @@ def test_can_get_geojson_simple(
             areas={
                 "ids": ["Bristol ID"],
                 "simple_polygons": [BRISTOL],
+                # We want the name in the JSON so make them different to the IDs for asserting``
                 "names": ["Bristol Name"],
             },
         ),

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -137,6 +137,12 @@ sample_uuid = sample_uuid()
             405,
         ),
         (
+            ".get_broadcast_geojson",
+            {"broadcast_message_id": sample_uuid},
+            403,
+            405,
+        ),
+        (
             ".cancel_broadcast_message",
             {"broadcast_message_id": sample_uuid},
             403,

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -78,6 +78,7 @@ EXCLUDED_ENDPOINTS = tuple(
             "find_services_by_name",
             "find_users_by_email",
             "forgot_password",
+            "get_broadcast_geojson",
             "history",
             "index",
             "information_risk_management",


### PR DESCRIPTION
This adds a new link that generates a geoJSON file on the fly. Most of the time was spent deciphering how BroadcastArea worked. The contents of the geoJSON is a Feature element for each area in the broadcast.

There's now a new link in the alert summary list (upcoming downloadables like CAP and IBAG are expected to be in this list):
<img width="810" alt="image" src="https://github.com/user-attachments/assets/100f32ad-329c-4aee-9748-b5c403874473" />

Which will prompt the browser to download it using the ref of the alert as a file name:
<img width="517" alt="image" src="https://github.com/user-attachments/assets/810c22e3-6a8d-4ecd-b456-5184385ad5e8" />

And then the contents of it can be viewed ...however geoJSON is normally used:
<img width="1797" alt="image" src="https://github.com/user-attachments/assets/4f6d5661-fb6e-4c11-86f5-a42dea72bc00" />

There doesn't appear to be a standard on how features are named (e.g. the spec specifies extra properties like `title` could be used, but aren't officially part of the spec and should be ignored) so I've settled on just using a property as at least it'll likely show up in a GUI:
<img width="791" alt="image" src="https://github.com/user-attachments/assets/a2c81dcd-0030-4275-bacb-37a4143e98fb" />
