### PR TITLE
EAS-2563 Remove tag styling

### DIFF
--- a/app/assets/stylesheets/govuk-frontend/overrides.scss
+++ b/app/assets/stylesheets/govuk-frontend/overrides.scss
@@ -70,17 +70,14 @@ $notify-secondary-button-hover-colour: govuk-shade(govuk-colour("light-grey"), 1
 }
 
 .govuk-tag.broadcast-tag {
-  @include govuk-tag-uppercase;
   background-color: govuk-colour("red");
 }
 
 .govuk-tag.draft-tag {
-  @include govuk-tag-uppercase;
   background-color: govuk-colour("blue");
 }
 
 .govuk-tag.elevated-tag {
-  @include govuk-tag-uppercase;
   background-color: govuk-colour("green");
 }
 

--- a/app/assets/stylesheets/govuk-frontend/overrides.scss
+++ b/app/assets/stylesheets/govuk-frontend/overrides.scss
@@ -54,21 +54,6 @@ $notify-secondary-button-hover-colour: govuk-shade(govuk-colour("light-grey"), 1
   }
 }
 
-@mixin govuk-tag-uppercase {
-  @include govuk-font($size: 16);
-  color: govuk-colour("white");
-  font-weight: 700;
-  outline: 2px solid transparent;
-  outline-offset: -2px;
-  letter-spacing: 1px;
-  text-transform: uppercase;
-  padding-top: 5px;
-  padding-right: 8px;
-  padding-bottom: 4px;
-  padding-left: 8px;
-  line-height: 1;
-}
-
 .govuk-tag.broadcast-tag {
   background-color: govuk-colour("red");
 }

--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -71,7 +71,7 @@
           "href": url_for('main.platform_admin_search'),
           "html": 'Platform admin' + (govukTag ({
               'text': 'Elevated',
-              'classes': 'govuk-!-margin-left-2 elevated-tag'
+              'classes': 'govuk-!-margin-left-2 govuk-tag--green'
             }) if current_user.platform_admin else ''),
           "active": header_navigation.is_selected('platform-admin')
         },

--- a/app/templates/views/broadcast/partials/broadcast-details.html
+++ b/app/templates/views/broadcast/partials/broadcast-details.html
@@ -4,8 +4,8 @@
 {% if broadcast_message.status == 'broadcasting' %}
 <p class="govuk-body govuk-!-margin-bottom-2 live-broadcast live-broadcast--left">
   {{ govukTag ({
-    'text': 'live',
-    'classes': 'govuk-!-margin-right-2 broadcast-tag'
+    'text': 'Live',
+    'classes': 'govuk-!-margin-right-2 govuk-tag--red'
   }) }}
   since {{ broadcast_message.starts_at|format_datetime_relative }}&ensp;
   {%- if not hide_stop_link %}

--- a/app/templates/views/broadcast/partials/dashboard-table.html
+++ b/app/templates/views/broadcast/partials/dashboard-table.html
@@ -22,8 +22,8 @@
       {% elif item.status == 'rejected' %}
         <p class="govuk-body live-broadcast file-list-status govuk-!-margin-top-2">
           {{ govukTag ({
-            'text': 'rejected',
-            'classes': 'govuk-!-margin-right-1 govuk-!-margin-top-2 broadcast-tag'
+            'text': 'Rejected',
+            'classes': 'govuk-!-margin-right-1 govuk-!-margin-top-2 govuk-tag--red'
           }) }}
           {{ item.updated_at|format_datetime_human }}
         </p>
@@ -33,16 +33,16 @@
       {% elif item.status == 'broadcasting' %}
         <p class="govuk-body live-broadcast file-list-status">
           {{ govukTag ({
-            'text': 'live',
-            'classes': 'govuk-!-margin-right-2 broadcast-tag'
+            'text': 'Live',
+            'classes': 'govuk-!-margin-right-2 govuk-tag--red'
           }) }}
           since {{ item.starts_at|format_datetime_relative }}
         </p>
       {% elif item.status == 'draft' %}
         <p class="govuk-body live-broadcast file-list-status">
           {{ govukTag ({
-            'text': 'draft',
-            'classes': 'govuk-!-margin-right-2 draft-tag'
+            'text': 'Draft',
+            'classes': 'govuk-!-margin-right-2 govuk-tag govuk-tag--blue'
           }) }}
         </p>
       {% else %}

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -574,11 +574,11 @@ def test_broadcast_dashboard(
     assert len(page.select(".ajax-block-container")) == len(page.select("h1")) == 1
 
     assert [normalize_spaces(row.text) for row in page.select(".ajax-block-container")[0].select(".file-list")] == [
-        "Example template This is a test draft",
+        "Example template This is a test Draft",
         "Half an hour ago This is a test Waiting for approval Area: England Scotland",
         "Hour and a half ago This is a test Waiting for approval Area: England Scotland",
-        "Example template This is a test live since today at 2:20am Area: England Scotland",
-        "Example template This is a test live since today at 1:20am Area: England Scotland",
+        "Example template This is a test Live since today at 2:20am Area: England Scotland",
+        "Example template This is a test Live since today at 1:20am Area: England Scotland",
     ]
 
 
@@ -664,7 +664,7 @@ def test_broadcast_dashboard_json(
 
     assert response_json.keys() == {"current_broadcasts"}
     assert "Waiting for approval" in broadcasts
-    assert "live since today at 2:20am" in broadcasts
+    assert "Live since today at 2:20am" in broadcasts
 
 
 @pytest.mark.parametrize(
@@ -720,7 +720,7 @@ def test_rejected_broadcasts_page(
     assert normalize_spaces(page.select_one("main h1").text) == "Rejected alerts"
     assert len(page.select(".ajax-block-container")) == 1
     assert [normalize_spaces(row.text) for row in page.select(".ajax-block-container")[0].select(".file-list")] == [
-        "Example template rejected today at 1:20am This is a test",
+        "Example template Rejected today at 1:20am This is a test",
     ]
 
 
@@ -3378,7 +3378,7 @@ def test_start_broadcasting(
                 "approved_by": "Bob",
             },
             [
-                "live since 20 February at 8:20pm Stop sending",
+                "Live since 20 February at 8:20pm Stop sending",
                 "40,000,000 phones estimated",
                 "Created by Alice and approved by Bob.",
                 "Broadcasting stops tomorrow at 11:23pm.",
@@ -3389,7 +3389,7 @@ def test_start_broadcasting(
             True,
             {"status": "broadcasting", "finishes_at": "2020-02-23T23:23:23.000000", "approved_by": "Alice"},
             [
-                "live since 20 February at 8:20pm Stop sending",
+                "Live since 20 February at 8:20pm Stop sending",
                 "40,000,000 phones estimated",
                 "Created from an API call and approved by Alice.",
                 "Broadcasting stops tomorrow at 11:23pm.",


### PR DESCRIPTION
This PR removes any custom styling applied to govukTag components used throughout the service, ensuring it is aligned with component (can be found [here](https://design-system.service.gov.uk/components/tag/)) and thus WCAG 2.2 compliant.