### PR TITLE
EAS-2602 + EAS-2603: Admin: Introduce new unsigned XML downloading capability

### DIFF
--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -1300,5 +1300,5 @@ def get_broadcast_unsigned_xml(service_id, broadcast_message_id, xml_type):
     return Response(
         cap_xml,
         mimetype="application/xml",
-        headers={"Content-Disposition": f"attachment;filename={broadcast_message.reference}.cap.xml"},
+        headers={"Content-Disposition": f"attachment;filename={broadcast_message.reference}.{xml_type}.xml"},
     )

--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -1261,7 +1261,7 @@ def get_broadcast_unsigned_cap(service_id, broadcast_message_id):
         "message_format": "cap",
         "headline": HEADLINE,
         "description": broadcast_message.content,
-        "language": "English",
+        "language": "en-GB",
         "areas": [
             {
                 # as_coordinate_pairs_lat_long returns an extra surrounding list.

--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -1,7 +1,11 @@
 import json
+from datetime import datetime, timedelta, timezone
 from typing import Collection
 
 from emergency_alerts_utils.template import BroadcastPreviewTemplate
+from emergency_alerts_utils.xml.broadcast import generate_xml_body
+from emergency_alerts_utils.xml.cap import convert_utc_datetime_to_cap_standard_string
+from emergency_alerts_utils.xml.common import HEADLINE
 from flask import (
     Response,
     abort,
@@ -1211,7 +1215,7 @@ def view_broadcast_versions(service_id, broadcast_message_id):
 def get_broadcast_geojson(service_id, broadcast_message_id):
     broadcast_message = BroadcastMessage.from_id(
         broadcast_message_id,
-        service_id=service_id,
+        service_id=current_service.id,
     )
 
     areas: Collection[BaseBroadcastArea] = broadcast_message.areas
@@ -1236,4 +1240,60 @@ def get_broadcast_geojson(service_id, broadcast_message_id):
         json.dumps(geojson),
         mimetype="application/geo+json",
         headers={"Content-Disposition": f"attachment;filename={broadcast_message.reference}.geojson"},
+    )
+
+
+@main.route("/services/<uuid:service_id>/broadcast/<uuid:broadcast_message_id>/xml/cap", methods=["GET"])
+@user_has_permissions()
+def get_broadcast_unsigned_cap(service_id, broadcast_message_id):
+    broadcast_message = BroadcastMessage.from_id(
+        broadcast_message_id,
+        service_id=current_service.id,
+    )
+
+    areas: Collection[BaseBroadcastArea] = broadcast_message.areas
+
+    event = {
+        # In a signed CAP message the identifier refers to a BroadcastProviderMessage which is unique per MNO
+        # We don't have such a thing here so we just use the overall BroadcastMessage
+        "identifier": broadcast_message_id,
+        "message_type": "alert",
+        "message_format": "cap",
+        "headline": HEADLINE,
+        "description": broadcast_message.content,
+        "language": "English",
+        "areas": [
+            {
+                # as_coordinate_pairs_lat_long returns an extra surrounding list.
+                # We do not expect this to ever have multiple items in.
+                # (API doesn't need to do this when generating events as it doesn't use the Polygon classes)
+                "polygon": area.polygons.as_coordinate_pairs_lat_long[0],
+            }
+            for area in areas
+        ],
+        "channel": current_service.broadcast_channel,
+        # starts_at and finishes_at can be None if it's a draft/awaiting approval, so we just use now
+        # sent and expires expect a string in 'CAP' format (see convert_utc_... method's description)
+        "sent": (
+            convert_utc_datetime_to_cap_standard_string(
+                datetime.fromisoformat(broadcast_message.starts_at)
+                if broadcast_message.starts_at
+                else datetime.now(timezone.utc)
+            )
+        ),
+        "expires": (
+            convert_utc_datetime_to_cap_standard_string(
+                datetime.fromisoformat(broadcast_message.finishes_at)
+                if broadcast_message.finishes_at
+                else datetime.now(timezone.utc) + timedelta(seconds=broadcast_message.broadcast_duration)
+            )
+        ),
+    }
+
+    cap_xml = generate_xml_body(event)
+
+    return Response(
+        cap_xml,
+        mimetype="application/xml",
+        headers={"Content-Disposition": f"attachment;filename={broadcast_message.reference}.cap.xml"},
     )

--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -1243,13 +1243,17 @@ def get_broadcast_geojson(service_id, broadcast_message_id):
     )
 
 
-@main.route("/services/<uuid:service_id>/broadcast/<uuid:broadcast_message_id>/xml/cap", methods=["GET"])
+@main.route("/services/<uuid:service_id>/broadcast/<uuid:broadcast_message_id>/xml/<xml_type>", methods=["GET"])
 @user_has_permissions()
-def get_broadcast_unsigned_cap(service_id, broadcast_message_id):
+def get_broadcast_unsigned_xml(service_id, broadcast_message_id, xml_type):
     broadcast_message = BroadcastMessage.from_id(
         broadcast_message_id,
         service_id=current_service.id,
     )
+
+    is_cap_format = True
+    if xml_type == "ibag":
+        is_cap_format = False
 
     areas: Collection[BaseBroadcastArea] = broadcast_message.areas
 
@@ -1258,10 +1262,11 @@ def get_broadcast_unsigned_cap(service_id, broadcast_message_id):
         # We don't have such a thing here so we just use the overall BroadcastMessage
         "identifier": broadcast_message_id,
         "message_type": "alert",
-        "message_format": "cap",
+        "message_format": "cap" if is_cap_format else "ibag",
+        "message_number": "00000001",  # Only relevant for IBAG, and is made up here
         "headline": HEADLINE,
         "description": broadcast_message.content,
-        "language": "en-GB",
+        "language": "en-GB" if is_cap_format else "English",
         "areas": [
             {
                 # as_coordinate_pairs_lat_long returns an extra surrounding list.

--- a/app/templates/components/alert-summary-list.html
+++ b/app/templates/components/alert-summary-list.html
@@ -198,15 +198,17 @@
         ) }}">
             <span class="govuk-visually-hidden">Download </span>geoJSON
         </a>
-        <br/>
-        <a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline" href="{{ url_for(
-            ".get_broadcast_unsigned_xml",
-            service_id=service_id,
-            broadcast_message_id=broadcast_message.id,
-            xml_type="cap",
-        ) }}">
-            <span class="govuk-visually-hidden">Download </span>CAP XML
-        </a>
+        {% for xml_type in ["cap", "ibag"] %}
+            <br/>
+            <a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline" href="{{ url_for(
+                ".get_broadcast_unsigned_xml",
+                service_id=service_id,
+                broadcast_message_id=broadcast_message.id,
+                xml_type=xml_type,
+            ) }}">
+                <span class="govuk-visually-hidden">Download </span>{{ xml_type | upper }} XML
+            </a>
+        {% endfor %}
     {% endset %}
     {% set summaryListItems = summaryListItems + [
         {

--- a/app/templates/components/alert-summary-list.html
+++ b/app/templates/components/alert-summary-list.html
@@ -200,9 +200,10 @@
         </a>
         <br/>
         <a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline" href="{{ url_for(
-            ".get_broadcast_unsigned_cap",
+            ".get_broadcast_unsigned_xml",
             service_id=service_id,
             broadcast_message_id=broadcast_message.id,
+            xml_type="cap",
         ) }}">
             <span class="govuk-visually-hidden">Download </span>CAP XML
         </a>

--- a/app/templates/components/alert-summary-list.html
+++ b/app/templates/components/alert-summary-list.html
@@ -198,6 +198,14 @@
         ) }}">
             <span class="govuk-visually-hidden">Download </span>geoJSON
         </a>
+        <br/>
+        <a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline" href="{{ url_for(
+            ".get_broadcast_unsigned_cap",
+            service_id=service_id,
+            broadcast_message_id=broadcast_message.id,
+        ) }}">
+            <span class="govuk-visually-hidden">Download </span>CAP XML
+        </a>
     {% endset %}
     {% set summaryListItems = summaryListItems + [
         {

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -5605,6 +5605,7 @@ def test_can_get_unsigned_cap_xml(
             starts_at="2020-02-20T20:20:20.000000",
             finishes_at="2020-02-20T23:20:20.000000",
             duration=10_800,
+            reference="Test name",
             content="Test content",
             areas={
                 "ids": ["Bristol"],
@@ -5626,6 +5627,7 @@ def test_can_get_unsigned_cap_xml(
     )
 
     assert xml_response.content_type == "application/xml; charset=utf-8"
+    assert xml_response.headers.get("Content-Disposition") == "attachment;filename=Test name.cap.xml"
 
     assert xml_path(
         xml_response.text,
@@ -5712,6 +5714,7 @@ def test_can_get_unsigned_ibag_xml(
             starts_at="2020-02-20T20:20:20.000000",
             finishes_at="2020-02-20T23:20:20.000000",
             duration=10_800,
+            reference="Test name",
             content="Test content",
             areas={
                 "ids": ["Bristol"],
@@ -5731,6 +5734,7 @@ def test_can_get_unsigned_ibag_xml(
     )
 
     assert xml_response.content_type == "application/xml; charset=utf-8"
+    assert xml_response.headers.get("Content-Disposition") == "attachment;filename=Test name.ibag.xml"
 
     assert xml_path(
         xml_response.text,

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -5723,7 +5723,6 @@ def test_can_get_unsigned_ibag_xml(
             },
         ),
     )
-    # TODO:
     # This nets us an 'Alert' msgType:
     service_one["broadcast_channel"] = "severe"
     service_one["permissions"] += ["broadcast"]

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -5619,9 +5619,10 @@ def test_can_get_unsigned_cap_xml(
 
     client_request.login(active_user_view_permissions)
     xml_response = client_request.get_response(
-        ".get_broadcast_unsigned_cap",
+        ".get_broadcast_unsigned_xml",
         service_id=SERVICE_ONE_ID,
         broadcast_message_id=fake_uuid,
+        xml_type="cap",
     )
 
     assert xml_response.content_type == "application/xml; charset=utf-8"
@@ -5689,4 +5690,149 @@ def test_can_get_unsigned_cap_xml(
     assert xml_path(
         xml_response.text,
         "/cap:alert/cap:info/cap:certainty//text()",
+    ) == ["Likely"]
+
+
+def test_can_get_unsigned_ibag_xml(
+    mocker,
+    client_request,
+    service_one,
+    active_user_view_permissions,
+    fake_uuid,
+    mock_get_broadcast_message_versions,
+):
+    mocker.patch(
+        "app.broadcast_message_api_client.get_broadcast_message",
+        return_value=broadcast_message_json(
+            id_=fake_uuid,
+            service_id=SERVICE_ONE_ID,
+            template_id=fake_uuid,
+            created_by_id=fake_uuid,
+            approved_by_id=fake_uuid,
+            starts_at="2020-02-20T20:20:20.000000",
+            finishes_at="2020-02-20T23:20:20.000000",
+            duration=10_800,
+            content="Test content",
+            areas={
+                "ids": ["Bristol"],
+                "simple_polygons": [BRISTOL],
+                "names": ["Bristol"],
+            },
+        ),
+    )
+    # TODO:
+    # This nets us an 'Alert' msgType:
+    service_one["broadcast_channel"] = "severe"
+    service_one["permissions"] += ["broadcast"]
+
+    client_request.login(active_user_view_permissions)
+    xml_response = client_request.get_response(
+        ".get_broadcast_unsigned_xml", service_id=SERVICE_ONE_ID, broadcast_message_id=fake_uuid, xml_type="ibag"
+    )
+
+    assert xml_response.content_type == "application/xml; charset=utf-8"
+
+    assert xml_path(
+        xml_response.text,
+        "/ibag:IBAG_Alert_Attributes/ibag:IBAG_sending_gateway_id//text()",
+        "ibag",
+    ) == ["broadcasts@notifications.service.gov.uk"]
+
+    assert xml_path(
+        xml_response.text,
+        "/ibag:IBAG_Alert_Attributes/ibag:IBAG_message_number//text()",
+        "ibag",
+    ) == ["00000001"]
+
+    assert xml_path(
+        xml_response.text,
+        "/ibag:IBAG_Alert_Attributes/ibag:IBAG_sender//text()",
+        "ibag",
+    ) == ["broadcasts@notifications.service.gov.uk"]
+
+    assert xml_path(
+        xml_response.text,
+        "/ibag:IBAG_Alert_Attributes/ibag:IBAG_sent_date_time//text()",
+        "ibag",
+    ) == ["2020-02-20T20:20:20-00:00"]
+
+    assert xml_path(
+        xml_response.text,
+        "/ibag:IBAG_Alert_Attributes/ibag:IBAG_status//text()",
+        "ibag",
+    ) == ["Actual"]
+
+    assert xml_path(
+        xml_response.text,
+        "/ibag:IBAG_Alert_Attributes/ibag:IBAG_message_type//text()",
+        "ibag",
+    ) == ["Alert"]
+
+    assert xml_path(
+        xml_response.text,
+        "/ibag:IBAG_Alert_Attributes/ibag:IBAG_cap_alert_uri//text()",
+        "ibag",
+    ) == ["https://www.gov.uk/alerts"]
+
+    assert xml_path(
+        xml_response.text,
+        "/ibag:IBAG_Alert_Attributes/ibag:IBAG_alert_info/ibag:IBAG_text_language//text()",
+        "ibag",
+    ) == ["English"]
+
+    assert xml_path(
+        xml_response.text,
+        "/ibag:IBAG_Alert_Attributes/ibag:IBAG_alert_info/ibag:IBAG_expires_date_time//text()",
+        "ibag",
+    ) == ["2020-02-20T23:20:20-00:00"]
+
+    assert xml_path(
+        xml_response.text,
+        "/ibag:IBAG_Alert_Attributes/ibag:IBAG_alert_info/ibag:IBAG_text_alert_message//text()",
+        "ibag",
+    ) == ["Test content"]
+
+    assert xml_path(
+        xml_response.text,
+        "/ibag:IBAG_Alert_Attributes/ibag:IBAG_alert_info/ibag:IBAG_text_alert_message_length//text()",
+        "ibag",
+    ) == [str(len("Test content"))]
+
+    assert xml_path(
+        xml_response.text,
+        "/ibag:IBAG_Alert_Attributes/ibag:IBAG_alert_info/ibag:IBAG_Alert_Area[1]/ibag:IBAG_area_description//text()",
+        "ibag",
+    ) == ["area-1"]
+
+    assert xml_path(
+        xml_response.text,
+        "/ibag:IBAG_Alert_Attributes/ibag:IBAG_alert_info/ibag:IBAG_Alert_Area[1]/ibag:IBAG_polygon//text()",
+        "ibag",
+        # TODO: Coordinate type?
+    ) == ["51.4371,-2.6216 51.4371,-2.575 51.4668,-2.575 51.4668,-2.6216 51.4371,-2.6216"]
+
+    assert xml_path(
+        xml_response.text,
+        "/ibag:IBAG_Alert_Attributes/ibag:IBAG_alert_info/ibag:IBAG_channel_category//text()",
+        "ibag",
+    ) == [
+        "4378-CAT3-ENGLISH"
+    ]  # Severe alert
+
+    assert xml_path(
+        xml_response.text,
+        "/ibag:IBAG_Alert_Attributes/ibag:IBAG_alert_info/ibag:IBAG_severity//text()",
+        "ibag",
+    ) == ["Severe"]
+
+    assert xml_path(
+        xml_response.text,
+        "/ibag:IBAG_Alert_Attributes/ibag:IBAG_alert_info/ibag:IBAG_urgency//text()",
+        "ibag",
+    ) == ["Expected"]
+
+    assert xml_path(
+        xml_response.text,
+        "/ibag:IBAG_Alert_Attributes/ibag:IBAG_alert_info/ibag:IBAG_certainty//text()",
+        "ibag",
     ) == ["Likely"]

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -36,6 +36,7 @@ from tests.conftest import (
     create_platform_admin_user,
     normalize_spaces,
 )
+from tests.utils import xml_path
 
 sample_uuid = sample_uuid()
 
@@ -5612,7 +5613,7 @@ def test_can_get_unsigned_cap_xml(
             },
         ),
     )
-    # This nets us an 'Alert' msgType
+    # This nets us an 'Alert' msgType:
     service_one["broadcast_channel"] = "severe"
     service_one["permissions"] += ["broadcast"]
 
@@ -5625,7 +5626,67 @@ def test_can_get_unsigned_cap_xml(
 
     assert xml_response.content_type == "application/xml; charset=utf-8"
 
-    assert (
-        xml_response.text
-        == '<alert xmlns="urn:oasis:names:tc:emergency:cap:1.2"><identifier>6ce466d0-fd6a-11e5-82f5-e0accb9d11a6</identifier><sender>broadcasts@notifications.service.gov.uk</sender><sent>2020-02-20T20:20:20-00:00</sent><status>Actual</status><msgType>Alert</msgType><scope>Public</scope><info><language>English</language><category>Safety</category><event>Alert</event><urgency>Expected</urgency><severity>Severe</severity><certainty>Likely</certainty><expires>2020-02-20T23:20:20-00:00</expires><senderName>GOV.UK Emergency Alerts</senderName><headline>GOV.UK Emergency Alert</headline><description>Test content</description><area><areaDesc>area-1</areaDesc><polygon>51.4371,-2.6216 51.4371,-2.575 51.4668,-2.575 51.4668,-2.6216 51.4371,-2.6216</polygon></area></info></alert>'  # noqa: E501
-    )
+    assert xml_path(
+        xml_response.text,
+        "/cap:alert/cap:identifier//text()",
+    ) == [fake_uuid]
+
+    assert xml_path(
+        xml_response.text,
+        "/cap:alert/cap:status//text()",
+    ) == ["Actual"]
+
+    assert xml_path(
+        xml_response.text,
+        "/cap:alert/cap:sent//text()",
+    ) == ["2020-02-20T20:20:20-00:00"]
+
+    assert xml_path(
+        xml_response.text,
+        "/cap:alert/cap:info/cap:language//text()",
+    ) == ["en-GB"]
+
+    assert xml_path(
+        xml_response.text,
+        "/cap:alert/cap:info/cap:expires//text()",
+    ) == ["2020-02-20T23:20:20-00:00"]
+
+    assert xml_path(
+        xml_response.text,
+        "/cap:alert/cap:info/cap:headline//text()",
+    ) == ["GOV.UK Emergency Alert"]
+
+    assert xml_path(
+        xml_response.text,
+        "/cap:alert/cap:info/cap:description//text()",
+    ) == ["Test content"]
+
+    assert xml_path(
+        xml_response.text,
+        "/cap:alert/cap:info/cap:area/cap:areaDesc//text()",
+    ) == ["area-1"]
+
+    assert xml_path(
+        xml_response.text,
+        "/cap:alert/cap:info/cap:area/cap:polygon//text()",
+    ) == ["51.4371,-2.6216 51.4371,-2.575 51.4668,-2.575 51.4668,-2.6216 51.4371,-2.6216"]
+
+    assert xml_path(
+        xml_response.text,
+        "/cap:alert/cap:info/cap:event//text()",
+    ) == ["Alert"]
+
+    assert xml_path(
+        xml_response.text,
+        "/cap:alert/cap:info/cap:urgency//text()",
+    ) == ["Expected"]
+
+    assert xml_path(
+        xml_response.text,
+        "/cap:alert/cap:info/cap:severity//text()",
+    ) == ["Severe"]
+
+    assert xml_path(
+        xml_response.text,
+        "/cap:alert/cap:info/cap:certainty//text()",
+    ) == ["Likely"]

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -3330,7 +3330,7 @@ def test_preview_broadcast_message_page(
         + "Use the buttons to zoom the map in or out View larger map",
         "",
         "40,000,000 phones estimated",
-        "Download geoJSON Download CAP XML",
+        "Download geoJSON Download CAP XML Download IBAG XML",
     ]
 
     form = page.select_one("form")
@@ -5520,7 +5520,7 @@ def test_view_draft_broadcast_message_page(
         + "Use the buttons to zoom the map in or out View larger map",
         "3 hours",
         "40,000,000 phones estimated",
-        "Download geoJSON Download CAP XML",
+        "Download geoJSON Download CAP XML Download IBAG XML",
     ]
 
 

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -3329,7 +3329,7 @@ def test_preview_broadcast_message_page(
         + "Use the buttons to zoom the map in or out View larger map",
         "",
         "40,000,000 phones estimated",
-        "Download geoJSON",
+        "Download geoJSON Download CAP XML",
     ]
 
     form = page.select_one("form")
@@ -5519,7 +5519,7 @@ def test_view_draft_broadcast_message_page(
         + "Use the buttons to zoom the map in or out View larger map",
         "3 hours",
         "40,000,000 phones estimated",
-        "Download geoJSON",
+        "Download geoJSON Download CAP XML",
     ]
 
 

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -79,7 +79,7 @@ EXCLUDED_ENDPOINTS = tuple(
             "find_users_by_email",
             "forgot_password",
             "get_broadcast_geojson",
-            "get_broadcast_unsigned_cap",
+            "get_broadcast_unsigned_xml",
             "history",
             "index",
             "information_risk_management",

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -79,6 +79,7 @@ EXCLUDED_ENDPOINTS = tuple(
             "find_users_by_email",
             "forgot_password",
             "get_broadcast_geojson",
+            "get_broadcast_unsigned_cap",
             "history",
             "index",
             "information_risk_management",

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,8 +1,29 @@
 from unittest.mock import PropertyMock
 
+from lxml import etree
+
 
 class ComparablePropertyMock(PropertyMock):
     """A minimal extension of PropertyMock that allows it to be compared against another value"""
 
     def __lt__(self, other):
         return self() < other
+
+
+# Differs to emergency_alerts_utils in that it takes strings
+# (and we shouldn't import test code from the utils module)
+def xml_path(alert_xml: str, path: str, format="cap"):
+    root = etree.fromstring(alert_xml)
+
+    if format == "cap":
+        ns = {
+            "cap": "urn:oasis:names:tc:emergency:cap:1.2",
+            "ds": "http://www.w3.org/2000/09/xmldsig#",
+        }
+    else:
+        ns = {
+            "ibag": "ibag:1.0",
+            "ds": "http://www.w3.org/2000/09/xmldsig#",
+        }
+
+    return root.xpath(path, namespaces=ns)


### PR DESCRIPTION
> **Requires https://github.com/alphagov/emergency-alerts-utils/pull/102**

This adds new download links to the alert's page next to geoJSON.

<img width="782" alt="image" src="https://github.com/user-attachments/assets/3e4fc43e-8059-4922-81a4-2a7aa7eb0285" />


This naturally produces the unsigned XML we want in the desired format. It also uses the alert reference as a file name hint to the browser:
<img width="834" alt="image" src="https://github.com/user-attachments/assets/228c8021-59be-400d-a3f4-510700124f89" />

There is a degree of overlap code-wide, as the logic which creates the 'lambda event' dict lives in the API, but I've tried to re-use as many constants as I could.


CAP:
<img width="662" alt="image" src="https://github.com/user-attachments/assets/28997260-b1e1-499a-8c80-24a7d17bd1a9" />


IBAG:
<img width="775" alt="image" src="https://github.com/user-attachments/assets/63d5d1aa-9e5b-4b0b-9d04-d45712cc99cf" />

(Polygons snipped for brevity. IBAG uses a hardcoded message number of `00000001`)