### PR TITLE
EAS-2683: Admin: Update ECS task definitions on deploy with commit image

### DIFF
--- a/.codepipeline/appspec-template.yaml
+++ b/.codepipeline/appspec-template.yaml
@@ -3,7 +3,7 @@ Resources:
   - TargetService:
       Type: AWS::ECS::Service
       Properties:
-        TaskDefinition: "$TASK_DEFINITION_ARN"
+        TaskDefinition: <TASK_DEFINITION>
         LoadBalancerInfo:
           ContainerName: "$CONTAINER_NAME"
           ContainerPort: "$CONTAINER_PORT"

--- a/.codepipeline/buildspec-admin-build.yml
+++ b/.codepipeline/buildspec-admin-build.yml
@@ -10,9 +10,11 @@ phases:
     commands:
       - |
         TAGS="-t $REPOSITORY_URI:latest -t $REPOSITORY_URI:pipeline_$EXECUTION_ID"
+        IMAGE_COMMIT_TAG=latest
         if [ -n "$COMMIT_ID" ]; then
           COMMIT_ID=$(echo $COMMIT_ID | cut -c 1-7)
           TAGS="$TAGS -t $REPOSITORY_URI:commit_$COMMIT_ID"
+          IMAGE_COMMIT_TAG=$REPOSITORY_URI:commit_$COMMIT_ID
         fi
       - echo Build started on `date`
       - echo Building Docker image...
@@ -29,7 +31,8 @@ phases:
       - echo Building complete on `date`
       - echo Pushing the Docker image...
       - docker push --all-tags $REPOSITORY_URI
-      - aws ecs describe-task-definition --task-definition $TASK_DEFINITION_ARN | jq '.taskDefinition' > taskdef.json
+      - aws ecs describe-task-definition --task-definition $TASK_DEFINITION_ARN > orig-taskdef.json
+      - cat orig-taskdef.json | jq '.taskDefinition | .containerDefinitions[].image = "'$IMAGE_COMMIT_TAG'"' > taskdef.json
       - envsubst < .codepipeline/appspec-template.yaml > appspec.yaml
 
 artifacts:


### PR DESCRIPTION
> **Requires https://github.com/alphagov/emergency-alerts-infra/pull/1383**

This is likely only temporary as it supports only the legacy pipelines. Ironically it makes the legacy unversioned pipelines, er, versioned. 🚀 

<img width="889" height="828" alt="image" src="https://github.com/user-attachments/assets/f2f82aec-c5fd-4243-a008-374045a7741b" />