### PR TITLE
Displaying default if alert reference resolves to 'None'

### DIFF
--- a/app/templates/components/alert-summary-list.html
+++ b/app/templates/components/alert-summary-list.html
@@ -121,7 +121,7 @@
             'text': "Reference"
         },
         'value': {
-            'text': broadcast_message.reference
+            'text': broadcast_message.reference or ""
         },
         'actions': {
             'items': [

--- a/app/templates/views/broadcast/_broadcast_message_history.html
+++ b/app/templates/views/broadcast/_broadcast_message_history.html
@@ -1,6 +1,6 @@
 <div class="govuk-grid-column-full alert-list-item">
   <div class="govuk-grid-column-full">
-    <h2 class="message-name">{{ broadcast_message.reference }}</h2>
+    <h2 class="message-name">{{ broadcast_message.reference or "Untitled alert"}}</h2>
     <p class="hint">
       {% if is_edited %}
         Edit made {% if broadcast_message.created_at %}{{ broadcast_message.created_at|format_datetime_normal }}{% endif %}

--- a/app/templates/views/broadcast/partials/dashboard-table.html
+++ b/app/templates/views/broadcast/partials/dashboard-table.html
@@ -8,7 +8,7 @@
   <div class="keyline-block">
     <div class="file-list file-list--sectioned govuk-!-margin-bottom-2">
       <h2>
-        <a class="file-list-filename-large govuk-link govuk-link--no-visited-state" href="{{ url_for(view_broadcast_endpoint, service_id=current_service.id, broadcast_message_id=item.id) }}">{{ item.reference or item.template.reference}}</a>
+        <a class="file-list-filename-large govuk-link govuk-link--no-visited-state" href="{{ url_for(view_broadcast_endpoint, service_id=current_service.id, broadcast_message_id=item.id) }}">{{ item.reference or item.template.reference or "Untitled alert"}}</a>
       </h2>
       {% if item.status != 'rejected' %}
         <span class="file-list-hint-large govuk-!-margin-bottom-2">

--- a/app/templates/views/broadcast/view-message.html
+++ b/app/templates/views/broadcast/view-message.html
@@ -27,7 +27,7 @@
   {% if broadcast_message.status == 'pending-approval' %}
     {% if broadcast_message.created_by_id and broadcast_message.created_by_id == current_user.id
       and current_user.has_permissions('create_broadcasts', 'approve_broadcasts', restrict_admin_usage=True) %}
-      {{ broadcast_message.reference }} is waiting for approval
+      {{ broadcast_message.reference or "Untitled alert"}} is waiting for approval
     {% elif current_user.has_permissions('approve_broadcasts', restrict_admin_usage=True) %}
       {% if broadcast_message.created_by %}
         {{ broadcast_message.created_by }}
@@ -35,12 +35,12 @@
         An API call
       {% endif %}
       wants to broadcast
-      {{ broadcast_message.reference }}
+      {{ broadcast_message.reference or "Untitled alert" }}
     {% else %}
       This alert is waiting for approval
     {% endif %}
   {% else %}
-    {{ broadcast_message.reference }}
+    {{ broadcast_message.reference  or "Untitled alert"}}
   {% endif %}
 {% endblock %}
 
@@ -116,7 +116,7 @@
   {% endif %}
 
   {% if broadcast_message.status == 'pending-approval' %}
-    {{ page_header(broadcast_message.reference) }}
+    {{ page_header(broadcast_message.reference or "Untitled alert") }}
     {% if broadcast_message.created_by_id and broadcast_message.created_by_id == current_user.id
       and current_user.has_permissions('create_broadcasts', 'approve_broadcasts', restrict_admin_usage=True) %}
       {% if current_service.live and broadcast_message.submitted_by_id != current_user.id %}
@@ -129,7 +129,7 @@
                 An API call
               {% endif %}
               wants to broadcast
-              {{ broadcast_message.reference }}
+              {{ broadcast_message.reference or "Untitled alert" }}
             </h1>
             {{ form.confirm(param_extensions={
               'formGroup': {
@@ -162,7 +162,7 @@
       {% else %}
         <div class="banner govuk-!-margin-bottom-6">
           <h1 class="govuk-heading-m govuk-!-margin-bottom-3">
-            {{ broadcast_message.reference }} is waiting for approval
+            {{ broadcast_message.reference or "Untitled alert" }} is waiting for approval
           </h1>
           {% if current_service.live %}
             <p class="govuk-body">
@@ -220,7 +220,7 @@
       and broadcast_message.submitted_by_id == current_user.id %}
       <div class="banner govuk-!-margin-bottom-6">
         <h1 class="govuk-heading-m govuk-!-margin-bottom-3">
-          {{ broadcast_message.reference }} is waiting for approval
+          {{ broadcast_message.reference or "Untitled alert" }} is waiting for approval
         </h1>
         <p class="govuk-body">
           You need another member of your team to approve your alert.
@@ -240,7 +240,7 @@
               An API call
             {% endif %}
             wants to broadcast
-            {{ broadcast_message.reference }}
+            {{ broadcast_message.reference or "Untitled alert" }}
           </h1>
           {% if current_service.live %}
             {{ form.confirm(param_extensions={
@@ -301,11 +301,11 @@
       </div>
     {% endif %}
   {% elif broadcast_message.status == 'returned' %}
-    {{ page_header(broadcast_message.reference) }}
+    {{ page_header(broadcast_message.reference or "Untitled alert") }}
   {% elif broadcast_message.status == 'draft' %}
-    {{ page_header(broadcast_message.reference) }}
+    {{ page_header(broadcast_message.reference or "Untitled alert") }}
   {% else %}
-    {{ page_header(broadcast_message.reference) }}
+    {{ page_header(broadcast_message.reference or "Untitled alert") }}
 
     {{broadcast_details(broadcast_message, current_service)}}
   {% endif %}

--- a/app/utils/broadcast.py
+++ b/app/utils/broadcast.py
@@ -512,7 +512,7 @@ def redirect_if_operator_service(broadcast_message_id):
 def check_for_missing_fields(broadcast_message):
     errors = []
     edit_url = url_for(
-        ".write_new_broadcast",
+        ".edit_broadcast",
         service_id=current_service.id,
         broadcast_message_id=broadcast_message.id,
     )


### PR DESCRIPTION
Following the template changes made in EAS-2644, we noticed that alerts made using template now have a reference of `None` and thus link to alert is not display properly on 'current-alerts'. This PR ensures that they will be displayed with default title of "Untitled alert", though with the validation we have in place it should not be the case that an alert can be created without a reference.