### PR TITLE
EAS-2826 Fix/Ensuring historic alerts, from Template, retain reference

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -727,6 +727,7 @@ def write_new_broadcast_from_template(service_id, template_id):
                     content=form.content.data,
                     reference=form.reference.data,
                     areas=template.areas,
+                    template_id=template_id,
                 )
             else:
                 message = BroadcastMessage.create_from_area(
@@ -734,6 +735,7 @@ def write_new_broadcast_from_template(service_id, template_id):
                     content=form.content.data,
                     reference=form.reference.data,
                     area_ids=template.area_ids,
+                    template_id=template_id,
                 )
         # Redirects to 'Choose library' page if created in operator service,
         # as you cannot add extra_content in operator service, otherwise redirects

--- a/app/models/broadcast_message.py
+++ b/app/models/broadcast_message.py
@@ -163,8 +163,9 @@ class BroadcastMessage(BaseBroadcast):
 
     @property
     def reference(self):
-        if self.template_id and not self._dict["reference"]:
-            return self._dict["reference"]
+        if self.template_id and self._dict["template_name"] and not self._dict["reference"]:
+            # Alert has been created in past using template and so reference not stored
+            return self._dict["template_name"]
         return self._dict["cap_event"] or self._dict["reference"]
 
     @property

--- a/app/notify_client/broadcast_message_api_client.py
+++ b/app/notify_client/broadcast_message_api_client.py
@@ -9,7 +9,7 @@ class BroadcastMessageAPIClient(AdminAPIClient):
             "service_id": service_id,
             "personalisation": {},
         }
-        if template_id and not reference and not content:
+        if template_id:
             data.update(template_id=template_id)
         if content:
             data.update(content=content)

--- a/app/templates/views/broadcast/partials/dashboard-table.html
+++ b/app/templates/views/broadcast/partials/dashboard-table.html
@@ -8,7 +8,7 @@
   <div class="keyline-block">
     <div class="file-list file-list--sectioned govuk-!-margin-bottom-2">
       <h2>
-        <a class="file-list-filename-large govuk-link govuk-link--no-visited-state" href="{{ url_for(view_broadcast_endpoint, service_id=current_service.id, broadcast_message_id=item.id) }}">{{ item.reference or item.template.reference or "Untitled alert"}}</a>
+        <a class="file-list-filename-large govuk-link govuk-link--no-visited-state" href="{{ url_for(view_broadcast_endpoint, service_id=current_service.id, broadcast_message_id=item.id) }}">{{ item.reference or item.template_name or "Untitled alert"}}</a>
       </h2>
       {% if item.status != 'rejected' %}
         <span class="file-list-hint-large govuk-!-margin-bottom-2">

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -440,6 +440,7 @@ def broadcast_message_json(
         "id": id_,
         "service_id": service_id,
         "template_id": template_id,
+        "template_name": None,
         "template_version": 123,
         "content": content or "This is a test",
         "reference": reference,


### PR DESCRIPTION
This PR remediates an issue where if an alert has been created from a Template (before #268 was merged) then the alert reference will be resolved as the default "Untitled alert" (as added in #277), as the reference wasn't stored for those created using Templates, it was just returned as "template_name" and this was adjusted in recent PR.

This PR resolves this issue by checking not only for alert reference but also for template_name, before displaying default reference if reference not set. 

Additionally, this PR ensures that `template_id` is posted alongside other data when alert is created, this was removed in earlier PR as the attributes were just copied across to alert, but this is useful to retain and didn't need to be changed.