### PR TITLE
EAS-2614 Ensure duration error message consistent with service's max permitted duration

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1104,7 +1104,6 @@ class ChooseDurationForm(StripWhitespaceForm):
     hours = GovukIntegerField(
         validators=[
             InputRequired("Hours required"),
-            NumberRange(min=0, max=22, message="Hours must be between 0 and 22"),
         ],
         param_extensions={
             "hint": {"text": "Hours"},
@@ -1132,6 +1131,7 @@ class ChooseDurationForm(StripWhitespaceForm):
 
         if duration < timedelta(minutes=30):
             self.minutes.errors.append("Duration must be at least 30 minutes")
+            return False
 
         if channel in ["test", "operator"]:
             if duration > timedelta(hours=4):


### PR DESCRIPTION
This PR removes the `NumberRange` validator from the 'hours' field, as it has a message of "Hours must be between 0 and 22" if fails and is not correct for training or operator services (max duration is different). The validator wasn't strictly necessary as there's a validation method set that checks the duration is within range for respective service after submission anyway.