### PR TITLE
Reduce minimum alert duration from 30 mins to 5 mins

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1129,8 +1129,8 @@ class ChooseDurationForm(StripWhitespaceForm):
 
         duration = timedelta(hours=hours, minutes=minutes)
 
-        if duration < timedelta(minutes=30):
-            self.minutes.errors.append("Duration must be at least 30 minutes")
+        if duration < timedelta(minutes=5):
+            self.minutes.errors.append("Duration must be at least 5 minutes")
             return False
 
         if channel in ["test", "operator"]:

--- a/tests/app/main/forms/test_choose_duration.py
+++ b/tests/app/main/forms/test_choose_duration.py
@@ -13,8 +13,8 @@ from app.main.forms import ChooseDurationForm
 )
 def test_choose_valid_duration(channel, hours, minutes):
     form = ChooseDurationForm(channel, duration=None)
-    form.hours.raw_data = 0
-    form.minutes.raw_data = 0
+    form.hours.raw_data = str(hours)
+    form.minutes.raw_data = str(minutes)
     assert form.validate()
 
 

--- a/tests/app/main/forms/test_choose_duration.py
+++ b/tests/app/main/forms/test_choose_duration.py
@@ -1,0 +1,50 @@
+import pytest
+
+from app.main.forms import ChooseDurationForm
+
+
+@pytest.mark.parametrize(
+    "channel, hours, minutes",
+    (
+        ("severe", 1, 1),
+        ("test", 1, 1),
+        ("operator", 1, 1),
+    ),
+)
+def test_choose_valid_duration(channel, hours, minutes):
+    form = ChooseDurationForm(channel, duration=None)
+    form.hours.raw_data = 0
+    form.minutes.raw_data = 0
+    assert form.validate()
+
+
+@pytest.mark.parametrize(
+    "channel",
+    (
+        ("severe"),
+        ("test"),
+        ("operator"),
+    ),
+)
+def test_choose_duration_no_duration_displays_error(channel):
+    form = ChooseDurationForm(channel, duration=None)
+    form.hours.raw_data = 0
+    form.minutes.raw_data = 0
+    form.validate()
+    assert form.hours.errors == []
+    assert form.minutes.errors == ["Duration must be at least 5 minutes"]
+
+
+@pytest.mark.parametrize(
+    "channel, hours, minutes",
+    (
+        ("severe", 22, 31),
+        ("test", 5, 0),
+        ("operator", 1, 1),
+    ),
+)
+def test_choose_duration_too_long_displays_error(channel, hours, minutes):
+    form = ChooseDurationForm(channel, duration=None)
+    form.hours.raw_data = 0
+    form.minutes.raw_data = 0
+    assert form.validate()


### PR DESCRIPTION
This PR reduces the minimum alert duration from 30 mins to 5 mins and adds unit tests to ensure `ChooseDurationForm` inputs validated correctly.