### PR TITLE
EAS-2834 Handle invalid area

### DIFF
--- a/app/broadcast_areas/models.py
+++ b/app/broadcast_areas/models.py
@@ -5,7 +5,7 @@ from emergency_alerts_utils.formatters import formatted_list
 from emergency_alerts_utils.polygons import Polygons
 from emergency_alerts_utils.serialised_model import SerialisedModelCollection
 from rtreelib import Rect
-from shapely import Polygon
+from shapely import Polygon, is_valid_reason
 from werkzeug.utils import cached_property
 
 from app.formatters import square_metres_to_square_miles
@@ -214,6 +214,12 @@ class CustomBroadcastAreas(SerialisedModelCollection):
 
     def is_valid_area(self):
         return all(Polygon(polygon).is_valid for polygon in self._polygons)
+
+    @cached_property
+    def invalid_reason(self):
+        # Returns to user only the first reason for why the shape is invalid, if multiple
+        # so user can correct invalid shapes one at a time
+        return [is_valid_reason(Polygon(polygon)) for polygon in self._polygons][0]
 
 
 class BroadcastAreaLibrary(SerialisedModelCollection, SortingAndEqualityMixin, GetItemByIdMixin):

--- a/app/broadcast_areas/models.py
+++ b/app/broadcast_areas/models.py
@@ -5,7 +5,7 @@ from emergency_alerts_utils.formatters import formatted_list
 from emergency_alerts_utils.polygons import Polygons
 from emergency_alerts_utils.serialised_model import SerialisedModelCollection
 from rtreelib import Rect
-from shapely import Polygon, is_valid_reason
+from shapely import Polygon
 from werkzeug.utils import cached_property
 
 from app.formatters import square_metres_to_square_miles
@@ -214,12 +214,6 @@ class CustomBroadcastAreas(SerialisedModelCollection):
 
     def is_valid_area(self):
         return all(Polygon(polygon).is_valid for polygon in self._polygons)
-
-    @cached_property
-    def invalid_reason(self):
-        # Returns to user only the first reason for why the shape is invalid, if multiple
-        # so user can correct invalid shapes one at a time
-        return [is_valid_reason(Polygon(polygon)) for polygon in self._polygons][0]
 
 
 class BroadcastAreaLibrary(SerialisedModelCollection, SortingAndEqualityMixin, GetItemByIdMixin):

--- a/app/broadcast_areas/models.py
+++ b/app/broadcast_areas/models.py
@@ -190,10 +190,13 @@ class CustomBroadcastArea(BaseBroadcastArea):
 
     @cached_property
     def count_of_phones(self):
-        return sum(
-            area.simple_polygons.ratio_of_intersection_with(self.polygons) * area.count_of_phones
-            for area in self.nearby_electoral_wards
-        )
+        try:
+            return sum(
+                area.simple_polygons.ratio_of_intersection_with(self.polygons) * area.count_of_phones
+                for area in self.nearby_electoral_wards
+            )
+        except Exception:
+            return 0
 
 
 class CustomBroadcastAreas(SerialisedModelCollection):
@@ -208,6 +211,9 @@ class CustomBroadcastAreas(SerialisedModelCollection):
             name=self.items[index],
             polygons=self._polygons if index == 0 else None,
         )
+
+    def is_valid_area(self):
+        return all(Polygon(polygon).is_valid for polygon in self._polygons)
 
 
 class BroadcastAreaLibrary(SerialisedModelCollection, SortingAndEqualityMixin, GetItemByIdMixin):

--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -40,6 +40,7 @@ from app.utils.broadcast import (
     format_areas_list,
     get_changed_alert_form_data,
     get_changed_extra_content_form_data,
+    get_error_message_from_topology_error,
     keep_alert_content_button_clicked,
     keep_alert_reference_button_clicked,
     overwrite_content_button_clicked,
@@ -538,7 +539,7 @@ def submit_broadcast_message(service_id, broadcast_message_id):
         return render_current_alert_page(broadcast_message, hide_stop_link=True, errors=errors)
 
     if type(broadcast_message.areas) is CustomBroadcastAreas and not broadcast_message.areas.is_valid_area():
-        errors = [{"text": "The area is invalid"}]
+        errors = [{"text": get_error_message_from_topology_error(broadcast_message.areas.invalid_reason)}]
         return render_current_alert_page(broadcast_message, hide_stop_link=True, errors=errors)
 
     broadcast_message.request_approval()

--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -35,6 +35,7 @@ from app.models.broadcast_message import BroadcastMessage, BroadcastMessages
 from app.models.template import Template
 from app.utils import service_has_permission
 from app.utils.broadcast import (
+    INVALID_AREA_ERROR_TEXT,
     _get_back_link_from_view_broadcast_endpoint,
     check_for_missing_fields,
     format_areas_list,
@@ -502,13 +503,7 @@ def preview_broadcast_message(service_id, broadcast_message_id):
     areas = format_areas_list(broadcast_message.areas)
 
     if is_custom_broadcast and not broadcast_message.areas.is_valid_area():
-        errors = [
-            {
-                "text": "The area used is invalid and the alert cannot be sent. If the alert was created"
-                " through the API, report it to the alert creator. Otherwise report it to the "
-                "Emergency Alerts team."
-            }
-        ]
+        errors = [{"text": INVALID_AREA_ERROR_TEXT}]
         return render_preview_alert_page(broadcast_message, is_custom_broadcast, areas, errors)
 
     if request.method == "POST":
@@ -549,13 +544,7 @@ def submit_broadcast_message(service_id, broadcast_message_id):
         return render_current_alert_page(broadcast_message, hide_stop_link=True, errors=errors)
 
     if type(broadcast_message.areas) is CustomBroadcastAreas and not broadcast_message.areas.is_valid_area():
-        errors = [
-            {
-                "text": "The area used is invalid and the alert cannot be sent. If the alert was created"
-                " through the API, report it to the alert creator. Otherwise report it to the "
-                "Emergency Alerts team."
-            }
-        ]
+        errors = [{"text": INVALID_AREA_ERROR_TEXT}]
         return render_current_alert_page(broadcast_message, hide_stop_link=True, errors=errors)
 
     broadcast_message.request_approval()

--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -500,6 +500,17 @@ def preview_broadcast_message(service_id, broadcast_message_id):
     )
     is_custom_broadcast = type(broadcast_message.areas) is CustomBroadcastAreas
     areas = format_areas_list(broadcast_message.areas)
+
+    if is_custom_broadcast and not broadcast_message.areas.is_valid_area():
+        errors = [
+            {
+                "text": "The area used is invalid and the alert cannot be sent. If the alert was created"
+                " through the API, report it to the alert creator. Otherwise report it to the "
+                "Emergency Alerts team."
+            }
+        ]
+        return render_preview_alert_page(broadcast_message, is_custom_broadcast, areas, errors)
+
     if request.method == "POST":
         try:
             broadcast_message.check_can_update_status("pending-approval")

--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -40,7 +40,6 @@ from app.utils.broadcast import (
     format_areas_list,
     get_changed_alert_form_data,
     get_changed_extra_content_form_data,
-    get_error_message_from_topology_error,
     keep_alert_content_button_clicked,
     keep_alert_reference_button_clicked,
     overwrite_content_button_clicked,
@@ -539,7 +538,13 @@ def submit_broadcast_message(service_id, broadcast_message_id):
         return render_current_alert_page(broadcast_message, hide_stop_link=True, errors=errors)
 
     if type(broadcast_message.areas) is CustomBroadcastAreas and not broadcast_message.areas.is_valid_area():
-        errors = [{"text": get_error_message_from_topology_error(broadcast_message.areas.invalid_reason)}]
+        errors = [
+            {
+                "text": "The area used is invalid and the alert cannot be sent. If the alert was created"
+                " through the API, report it to the alert creator. Otherwise report it to the "
+                "Emergency Alerts team."
+            }
+        ]
         return render_current_alert_page(broadcast_message, hide_stop_link=True, errors=errors)
 
     broadcast_message.request_approval()

--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -537,6 +537,10 @@ def submit_broadcast_message(service_id, broadcast_message_id):
     if errors := check_for_missing_fields(broadcast_message):
         return render_current_alert_page(broadcast_message, hide_stop_link=True, errors=errors)
 
+    if type(broadcast_message.areas) is CustomBroadcastAreas and not broadcast_message.areas.is_valid_area():
+        errors = [{"text": "The area is invalid"}]
+        return render_current_alert_page(broadcast_message, hide_stop_link=True, errors=errors)
+
     broadcast_message.request_approval()
     return redirect(
         url_for(

--- a/app/utils/broadcast.py
+++ b/app/utils/broadcast.py
@@ -359,7 +359,13 @@ def render_current_alert_page(
     errors=None,
 ):
     if type(broadcast_message.areas) is CustomBroadcastAreas and not broadcast_message.areas.is_valid_area():
-        errors = [{"text": get_error_message_from_topology_error(broadcast_message.areas.invalid_reason)}]
+        errors = [
+            {
+                "text": "The area used is invalid and the alert cannot be sent. If the alert "
+                "was created through the API, report it to the alert creator. Otherwise report "
+                "it to the Emergency Alerts team."
+            }
+        ]
 
     return render_template(
         "views/broadcast/view-message.html",
@@ -594,32 +600,3 @@ def get_message_type(message_type):
         "broadcast": BroadcastMessage,
         "templates": Template,
     }[message_type]
-
-
-def get_error_message_from_topology_error(error_msg):
-    error_message_translations = {
-        "Topology Validation Error": (
-            "There’s a problem with the shape.",
-            " Make sure the outline is complete and does not overlap itself.",
-        ),
-        "Repeated Point": "The shape has the same point twice in a row. Remove any duplicate points.",
-        "Interior is disconnected": "Parts of the shape are not connected. The inside must be one continuous area.",
-        "Ring Self-intersection": "The shape loops back on itself. Check for twists or loops on the shape edges.",
-        "Self-intersection": "The shape crosses over itself. Adjust the outline so the edges do not cross.",
-        "Nested shells": (
-            "The shape has more than one outer boundary and they overlap. Separate ",
-            "the boundaries into individual shapes.",
-        ),
-        "Duplicate Rings": "The shape has the same boundary twice. Remove any duplicates.",
-        "Too few distinct points in geometry component": (
-            "The shape does not have enough points to make a valid " "outline. Add more points and close the shape."
-        ),
-        "Invalid Coordinate": "The shape contains an invalid point. Check the coordinates and correct them.",
-        "Ring is not closed": "The outline is not closed. The first and last point must be the same.",
-    }
-    return next(
-        (
-            message for key, message in error_message_translations.items() if key in error_msg
-        ),  # Returns the first value for which the key is within the error_msg string
-        "There's a problem with the area. Check that it is correct.",
-    )

--- a/app/utils/broadcast.py
+++ b/app/utils/broadcast.py
@@ -359,7 +359,7 @@ def render_current_alert_page(
     errors=None,
 ):
     if type(broadcast_message.areas) is CustomBroadcastAreas and not broadcast_message.areas.is_valid_area():
-        errors = [{"text": "The area is invalid"}]
+        errors = [{"text": get_error_message_from_topology_error(broadcast_message.areas.invalid_reason)}]
 
     return render_template(
         "views/broadcast/view-message.html",
@@ -594,3 +594,32 @@ def get_message_type(message_type):
         "broadcast": BroadcastMessage,
         "templates": Template,
     }[message_type]
+
+
+def get_error_message_from_topology_error(error_msg):
+    error_message_translations = {
+        "Topology Validation Error": (
+            "There’s a problem with the shape.",
+            " Make sure the outline is complete and does not overlap itself.",
+        ),
+        "Repeated Point": "The shape has the same point twice in a row. Remove any duplicate points.",
+        "Interior is disconnected": "Parts of the shape are not connected. The inside must be one continuous area.",
+        "Ring Self-intersection": "The shape loops back on itself. Check for twists or loops on the shape edges.",
+        "Self-intersection": "The shape crosses over itself. Adjust the outline so the edges do not cross.",
+        "Nested shells": (
+            "The shape has more than one outer boundary and they overlap. Separate ",
+            "the boundaries into individual shapes.",
+        ),
+        "Duplicate Rings": "The shape has the same boundary twice. Remove any duplicates.",
+        "Too few distinct points in geometry component": (
+            "The shape does not have enough points to make a valid " "outline. Add more points and close the shape."
+        ),
+        "Invalid Coordinate": "The shape contains an invalid point. Check the coordinates and correct them.",
+        "Ring is not closed": "The outline is not closed. The first and last point must be the same.",
+    }
+    return next(
+        (
+            message for key, message in error_message_translations.items() if key in error_msg
+        ),  # Returns the first value for which the key is within the error_msg string
+        "There's a problem with the area. Check that it is correct.",
+    )

--- a/app/utils/broadcast.py
+++ b/app/utils/broadcast.py
@@ -19,6 +19,12 @@ from app.main.forms import (
 from app.models.broadcast_message import BroadcastMessage
 from app.models.template import Template
 
+INVALID_AREA_ERROR_TEXT = (
+    "The area used is invalid and the alert cannot be sent. If the alert "
+    "was created through the API, report it to the alert creator. Otherwise report "
+    "it to the Emergency Alerts team."
+)
+
 
 def create_coordinate_area_slug(coordinate_type, first_coordinate, second_coordinate, radius):
     radius_min_sig_figs = format_number_no_scientific(radius)
@@ -359,13 +365,7 @@ def render_current_alert_page(
     errors=None,
 ):
     if type(broadcast_message.areas) is CustomBroadcastAreas and not broadcast_message.areas.is_valid_area():
-        errors = [
-            {
-                "text": "The area used is invalid and the alert cannot be sent. If the alert "
-                "was created through the API, report it to the alert creator. Otherwise report "
-                "it to the Emergency Alerts team."
-            }
-        ]
+        errors = [{"text": INVALID_AREA_ERROR_TEXT}]
 
     return render_template(
         "views/broadcast/view-message.html",

--- a/app/utils/broadcast.py
+++ b/app/utils/broadcast.py
@@ -358,6 +358,9 @@ def render_current_alert_page(
     hide_stop_link=False,
     errors=None,
 ):
+    if type(broadcast_message.areas) is CustomBroadcastAreas and not broadcast_message.areas.is_valid_area():
+        errors = [{"text": "The area is invalid"}]
+
     return render_template(
         "views/broadcast/view-message.html",
         broadcast_message=broadcast_message,

--- a/requirements.in
+++ b/requirements.in
@@ -20,6 +20,7 @@ pwdpy==1.0.1
 itsdangerous==2.1.2
 govuk-frontend-jinja==3.3.0
 govuk-bank-holidays==0.15
+shapely==2.1.1
 
 # Packages for testing
 black==25.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -104,6 +104,8 @@ mypy-extensions==1.1.0
     # via black
 notifications-python-client==8.0.0
     # via -r requirements.in
+numpy==2.3.3
+    # via shapely
 packaging==25.0
     # via
     #   black
@@ -166,6 +168,8 @@ rtreelib==0.2.0
     # via -r requirements.in
 s3transfer==0.13.0
     # via boto3
+shapely==2.1.1
+    # via -r requirements.in
 six==1.17.0
     # via
     #   python-dateutil

--- a/tests/app/models/test_broadcast_message.py
+++ b/tests/app/models/test_broadcast_message.py
@@ -198,6 +198,12 @@ def test_create_from_custom_area(mocker, service_one, fake_uuid, mock_create_bro
     )
 
 
+def test_invalid_area_returns_is_valid_False():
+    invalid_polygon = [[51.5310, -0.1580], [51.5310, -0.1570], [51.5310, -0.1580], [51.5310, -0.2]]
+    custom_areas = CustomBroadcastAreas(names="invalid area", polygons=[invalid_polygon])
+    assert custom_areas.is_valid_area() is False
+
+
 def test_create_from_content(mocker, service_one, fake_uuid, mock_create_broadcast_message):
     # Asserts that once class method create_from_content called, the mocked API
     # client method (broadcast_message_api_client.create_broadcast_message) is called


### PR DESCRIPTION
This PR ensures that if an area is invalid, an error persists on the view/preview alert pages and will prevent submission of the alert.
This PR adds the `is_valid_area` method to `CustomBroadcastAreas` model and uses shapely to validate that the area is valid, this is then checked against in various routes.
The original issue - error page displayed when trying to access an alert with an invalid area, has been resolved by handling the exception (returning 0 for the model attribute if there's an exception) but to display the error the area is validated.