### PR TITLE
Fix: Setting default for `rejected_at` where `rejected_at` now used more widely

### DIFF
--- a/app/templates/views/broadcast/partials/broadcast-details.html
+++ b/app/templates/views/broadcast/partials/broadcast-details.html
@@ -13,10 +13,11 @@
   {% endif %}
 </p>
 {% elif broadcast_message.status == 'rejected' %}
+{% set rejection_time = broadcast_message.rejected_at if broadcast_message.rejected_at else broadcast_message.updated_at %}
 <p class="govuk-body govuk-!-margin-bottom-4">
   {% if broadcast_message.rejected_by or broadcast_message.rejected_by_api_key_id %}
     Rejected
-    {{ broadcast_message.rejected_at|format_datetime_human }}
+    {{ rejection_time|format_datetime_human }}
     {% if broadcast_message.rejected_by %}
       by {{broadcast_message.rejected_by}}.
     {% elif broadcast_message.rejected_by_api_key_id %}
@@ -24,7 +25,7 @@
     {% endif %}
   {% else %}
     Rejected
-    {{ broadcast_message.rejected_at|format_datetime_human }}.
+    {{ rejection_time|format_datetime_human }}.
   {% endif %}
 </p>
 {% if broadcast_message.rejection_reason %}

--- a/app/templates/views/broadcast/partials/dashboard-table.html
+++ b/app/templates/views/broadcast/partials/dashboard-table.html
@@ -20,12 +20,13 @@
           Waiting for approval
         </p>
       {% elif item.status == 'rejected' %}
+        {% set rejection_time = item.rejected_at if item.rejected_at else item.updated_at %}
         <p class="govuk-body live-broadcast file-list-status govuk-!-margin-top-2">
           {{ govukTag ({
             'text': 'rejected',
             'classes': 'govuk-!-margin-right-1 govuk-!-margin-top-2 broadcast-tag'
           }) }}
-          {{ item.rejected_at|format_datetime_human }}
+          {{ rejection_time|format_datetime_human }}
         </p>
         <span class="file-list-hint-large govuk-!-margin-bottom-2">
           {{ item.content }}
@@ -75,12 +76,13 @@
     </div>
     <div>
       {% if item.status == 'rejected' %}
+        {% set rejection_time = item.rejected_at if item.rejected_at else item.updated_at %}
         <div class="govuk-!-margin-bottom-2">
           <p class="govuk-!-margin-right-1 dashboard-table govuk-!-font-weight-bold">Broadcast: </p>
           <p class="govuk-body dashboard-table">
           {% if item.rejected_by_api_key_id or item.rejected_by %}
             Rejected
-            {{ item.rejected_at|format_datetime_human }}
+            {{ rejection_time|format_datetime_human }}
             {% if item.rejected_by %}
               by {{item.rejected_by}}.
             {% elif item.rejected_by_api_key_id %}
@@ -88,7 +90,7 @@
             {% endif %}
           {% else %}
             Rejected
-            {{ item.rejected_at|format_datetime_human }}.
+            {{ rejection_time|format_datetime_human }}.
           {% endif %}
           </p>
         </div>

--- a/app/templates/views/broadcast/partials/status-history.html
+++ b/app/templates/views/broadcast/partials/status-history.html
@@ -37,8 +37,9 @@
         {% endif %}
 
         {%- if broadcast_message.status == 'rejected' and broadcast_message.rejected_by %}
+            {% set rejection_time = broadcast_message.rejected_at if broadcast_message.rejected_at else broadcast_message.updated_at %}
             <p class="govuk-body govuk-!-margin-bottom-3">
-                Rejected by {{broadcast_message.rejected_by}} on {{broadcast_message.rejected_at | format_datetime_short}}.
+                Rejected by {{broadcast_message.rejected_by}} on {{rejection_time | format_datetime_short}}.
             </p>
         {%- endif %}
 


### PR DESCRIPTION
This PR resolves an issue where if an alert that has been rejected doesn't have a `rejected_at` timestamp, i.e. from before we started storing them [here](https://github.com/alphagov/emergency-alerts-api/pull/177), the `updated_at` timestamp is instead displayed as this should be the last change made to a rejected alert regardless.