### PR TITLE
EAS-2905: Admin: Don't ship NodeJS in final image

### DIFF
--- a/Dockerfile.eas-admin
+++ b/Dockerfile.eas-admin
@@ -6,29 +6,43 @@ ARG RESOURCE_PREFIX=eas-app
 ARG AWS_REGION=eu-west-2
 ARG BASE_VERSION=latest
 ARG BASE_IMAGE=${ECS_ACCOUNT_NUMBER}.dkr.ecr.${AWS_REGION}.amazonaws.com/${RESOURCE_PREFIX}-base:${BASE_VERSION}
-FROM ${BASE_IMAGE}
+FROM ${BASE_IMAGE} AS build
 
 ARG APP_VERSION=unknown
 
-ENV SERVICE='admin'
+# Grab nvm and NodeJS, configuring future commands to work without sourcing
+SHELL ["/bin/bash", "-c"]
+ENV BASH_ENV /home/easuser/.bash_env
+RUN touch "${BASH_ENV}"
+RUN echo '. "${BASH_ENV}"' >> ~/.bashrc
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | PROFILE="${BASH_ENV}" bash
+RUN nvm install v22.21.1 && nvm use v22.21.1
 
 # Create root directory and copy repo
 COPY --chown=easuser:easuser . $DIR_ADMIN
 
-# Run emergency-alerts-admin
+# Bootstrap venv and emergency-alerts-admin
 RUN python$PYTHON_VERSION -m venv $VENV_ADMIN
 RUN cd $DIR_ADMIN && \
     . $VENV_ADMIN/bin/activate && \
     APP_VERSION=${APP_VERSION} make bootstrap
 
-# Create a blank configuration file
-RUN echo "" > $DIR_ADMIN/environment.sh
-
-COPY --chown=easuser:easuser scripts/start.sh /
-
-# Getting rid of our `node_modules`, because we only need them at build-time.
+# Get rid of our `node_modules` because we only need them at build-time.
 RUN rm -rf $DIR_ADMIN/node_modules
 
+# ---------
+# We can now use a fresh base as a small final image without NodeJS
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE} AS final
+
+ENV SERVICE='admin'
+
+# Copy over bootstrapped contents
+COPY --chown=easuser:easuser --from=build $VENV_ADMIN $VENV_ADMIN
+COPY --chown=easuser:easuser --from=build $DIR_ADMIN $DIR_ADMIN
+
+RUN echo "" > $DIR_ADMIN/environment.sh
+COPY --chown=easuser:easuser scripts/start.sh /
 CMD bash /start.sh
 
 EXPOSE 6012

--- a/Makefile
+++ b/Makefile
@@ -13,107 +13,24 @@ BUCKET_NAME = ${BROADCAST_AREAS_BUCKET_NAME}
 VIRTUALENV_ROOT := $(shell [ -z $$VIRTUAL_ENV ] && echo $$(pwd)/venv || echo $$VIRTUAL_ENV)
 PYTHON_EXECUTABLE_PREFIX := $(shell test -d "$${VIRTUALENV_ROOT}" && echo "$${VIRTUALENV_ROOT}/bin/" || echo "")
 
-NVM_VERSION := 0.40.3
-NODE_VERSION := 22.21.0
-
-write-source-file:
-	@if [ -f ~/.zshrc ]; then \
-		if [[ $$(cat ~/.zshrc | grep "export NVM") ]]; then \
-			cat ~/.zshrc | grep "export NVM" | sed "s/export//" > ~/.nvm-source; \
-		else \
-			cat ~/.bashrc | grep "export NVM" | sed "s/export//" > ~/.nvm-source; \
-		fi \
-	else \
-		cat ~/.bashrc | grep "export NVM" | sed "s/export//" > ~/.nvm-source; \
-	fi
-
-read-source-file: write-source-file
-	@if [ ! -f ~/.nvm-source ]; then \
-		echo "Source file could not be read"; \
-		exit 1; \
-	fi
-
-	@for line in $$(cat ~/.nvm-source); do \
-		export $$line; \
-	done; \
-	echo '. "$$NVM_DIR/nvm.sh"' >> ~/.nvm-source;
-
-	@if [[ "$(NVM_DIR)" == "" || ! -f "$(NVM_DIR)/nvm.sh" ]]; then \
-		mkdir -p $(HOME)/.nvm; \
-		export NVM_DIR=$(HOME)/.nvm; \
-		curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v$(NVM_VERSION)/install.sh | bash; \
-		echo ""; \
-		$(MAKE) write-source-file; \
-		for line in $$(cat ~/.nvm-source); do \
-			export $$line; \
-		done; \
-		echo '. "$$NVM_DIR/nvm.sh"' >> ~/.nvm-source; \
-	fi
-
-	@current_nvm_version=$$(. ~/.nvm-source && nvm --version); \
-	echo "NVM Versions (current/expected): $$current_nvm_version/$(NVM_VERSION)";
-
-upgrade-node:
-	@TEMPDIR=/tmp/node-upgrade; \
-	if [[ -d $(NVM_DIR)/versions ]]; then \
-		rm -rf $$TEMPDIR; \
-		mkdir $$TEMPDIR; \
-		cp -rf $(NVM_DIR)/versions $$TEMPDIR; \
-		echo "Node versions temporarily backed up to: $$TEMPDIR"; \
-	fi; \
-	rm -rf $(NVM_DIR); \
-	$(MAKE) read-source-file; \
-	if [[ -d $$TEMPDIR/versions ]]; then \
-		cp -rf $$TEMPDIR/versions $(NVM_DIR); \
-		echo "Restored node versions from: $$TEMPDIR"; \
-	fi;
-
-.PHONY: install-nvm
-install-nvm:
-	@echo ""
-	@echo "[Install Node Version Manager]"
-	@echo ""
-
-	@if [[ "$(NVM_VERSION)" == "" ]]; then \
-		echo "NVM_VERSION cannot be empty."; \
-		exit 1; \
-	fi
-
-	@$(MAKE) read-source-file
-
-	@current_nvm_version=$$(. ~/.nvm-source && nvm --version); \
-	if [[ "$(NVM_VERSION)" != "$$current_nvm_version" ]]; then \
-		$(MAKE) upgrade-node; \
-	fi
-
-.PHONY: install-node
-install-node: install-nvm
-	@echo ""
-	@echo "[Install Node]"
-	@echo ""
-
-	@. ~/.nvm-source && nvm install $(NODE_VERSION) \
-		&& nvm use $(NODE_VERSION) \
-		&& nvm alias default $(NODE_VERSION);
-
 ## DEVELOPMENT
 .PHONY: bootstrap
-bootstrap: generate-version-file install-node ## Set up everything to run the app
+bootstrap: generate-version-file ## Set up everything to run the app
 	${PYTHON_EXECUTABLE_PREFIX}pip3 install -r requirements_local_utils.txt
-	. ~/.nvm-source && npm ci --no-audit
-	. ~/.nvm-source && npm run build
+	npm ci --no-audit
+	npm run build
 	. environment.sh; ./scripts/get-broadcast-areas-db.sh ./app/broadcast_areas $(BUCKET_NAME)
 
 
 .PHONY: bootstrap-for-tests
-bootstrap-for-tests: generate-version-file install-node ## Set up everything to run the tests
+bootstrap-for-tests: generate-version-file ## Set up everything to run the tests
 	${PYTHON_EXECUTABLE_PREFIX}pip3 install -r requirements_github_utils.txt
-	. ~/.nvm-source && npm ci --no-audit
-	. ~/.nvm-source && npm run build
+	npm ci --no-audit
+	npm run build
 
 .PHONY: watch-frontend
 watch-frontend:  ## Build frontend and watch for changes
-	. ~/.nvm-source && . environment.sh; npm run watch
+	. environment.sh; npm run watch
 
 .PHONY: run-flask
 run-flask:  ## Run flask
@@ -125,7 +42,7 @@ run-flask-debug: ## Run flask in debug mode
 
 .PHONY: npm-audit
 npm-audit:  ## Check for vulnerabilities in NPM packages
-	. ~/.nvm-source && npm run audit
+	npm run audit
 
 .PHONY: help
 help:
@@ -148,7 +65,7 @@ test: ## Run tests
 	flake8 .
 	isort --check-only ./app ./tests
 	black --check .
-	. ~/.nvm-source && npm test
+	npm test
 	py.test -n auto --maxfail=10 tests/
 
 .PHONY: fix-imports


### PR DESCRIPTION
This uses a mutli-stage build so that NodeJS is only installed and executed during the build phase and we have no layers where we ship NodeJS or any JS depdencies - saving about 200MB.

I also get rid of most of the nvm junk in the Makefile - I presume it was there to workaround bash not sourcing its profile scripts during non-interactive shells. Either way it's always been weird that the Makefile does system-wide changes.