### PR TITLE
Revert "EAS-2892: Resolving the incorrect area creation issue with Template create_from_area method (#297)"

### DIFF
--- a/app/broadcast_areas/utils.py
+++ b/app/broadcast_areas/utils.py
@@ -1,7 +1,4 @@
-import itertools
 from collections import defaultdict
-
-from emergency_alerts_utils.polygons import Polygons
 
 from app.broadcast_areas.models import CustomBroadcastArea
 
@@ -81,42 +78,3 @@ def generate_aggregate_names(areas):
         else:
             aggregate_names.append(area.name)
     return aggregate_names
-
-
-def create_areas_dict(areas):
-    polygons = get_polygons_from_areas(areas, "simple_polygons")
-    return {
-        "ids": [area.id for area in areas],
-        "names": [area.name for area in areas],
-        "aggregate_names": [area.name for area in aggregate_areas(areas)],
-        "simple_polygons": polygons.as_coordinate_pairs_lat_long,
-    }
-
-
-def get_polygons_from_areas(areas, area_attribute):
-    areas_polygons = [getattr(area, area_attribute) for area in areas]
-    coordinate_reference_systems = {polygons.utm_crs for polygons in areas_polygons}
-
-    if len(coordinate_reference_systems) == 1:
-        # All our polygons are defined in the same coordinate
-        # reference system so we just have to flatten the list and
-        # say which coordinate reference system we are using
-        polygons = Polygons(
-            list(itertools.chain(*areas_polygons)),
-            utm_crs=next(iter(coordinate_reference_systems)),
-        )
-    else:
-        # Our polygons are in different coordinate reference systems
-        # We need to convert them back to degrees and make a new
-        # instance of `Polygons` which will determine a common
-        # coordinate reference system
-        polygons = Polygons(
-            list(itertools.chain(*(area_polygon.as_wgs84_coordinates for area_polygon in areas_polygons)))
-        )
-
-    if area_attribute != "polygons" and len(areas) > 1:
-        # We’re combining simplified polygons from multiple areas so we
-        # need to re-simplify the combined polygons to keep the point
-        # count down
-        return polygons.smooth.simplify
-    return polygons

--- a/app/models/base_broadcast.py
+++ b/app/models/base_broadcast.py
@@ -1,3 +1,6 @@
+import itertools
+
+from emergency_alerts_utils.polygons import Polygons
 from flask import current_app
 from ordered_set import OrderedSet
 from werkzeug.utils import cached_property
@@ -7,11 +10,7 @@ from app.broadcast_areas.models import (
     CustomBroadcastAreas,
     broadcast_area_libraries,
 )
-from app.broadcast_areas.utils import (
-    aggregate_areas,
-    generate_aggregate_names,
-    get_polygons_from_areas,
-)
+from app.broadcast_areas.utils import aggregate_areas, generate_aggregate_names
 from app.formatters import round_to_significant_figures
 from app.models import JSONModel
 
@@ -84,15 +83,15 @@ class BaseBroadcast(JSONModel):
 
     @cached_property
     def polygons(self):
-        return get_polygons_from_areas(self.areas, area_attribute="polygons")
+        return self.get_polygons_from_areas(area_attribute="polygons")
 
     @cached_property
     def simple_polygons(self):
-        return get_polygons_from_areas(self.areas, area_attribute="simple_polygons")
+        return self.get_polygons_from_areas(area_attribute="simple_polygons")
 
     @cached_property
     def simple_polygons_with_bleed(self):
-        return get_polygons_from_areas(self.areas, area_attribute="simple_polygons_with_bleed")
+        return self.get_polygons_from_areas(area_attribute="simple_polygons_with_bleed")
 
     @cached_property
     def count_of_phones(self):
@@ -135,6 +134,34 @@ class BaseBroadcast(JSONModel):
 
     def get_areas(self, area_ids):
         return broadcast_area_libraries.get_areas(area_ids)
+
+    def get_polygons_from_areas(self, area_attribute):
+        areas_polygons = [getattr(area, area_attribute) for area in self.areas]
+        coordinate_reference_systems = {polygons.utm_crs for polygons in areas_polygons}
+
+        if len(coordinate_reference_systems) == 1:
+            # All our polygons are defined in the same coordinate
+            # reference system so we just have to flatten the list and
+            # say which coordinate reference system we are using
+            polygons = Polygons(
+                list(itertools.chain(*areas_polygons)),
+                utm_crs=next(iter(coordinate_reference_systems)),
+            )
+        else:
+            # Our polygons are in different coordinate reference systems
+            # We need to convert them back to degrees and make a new
+            # instance of `Polygons` which will determine a common
+            # coordinate reference system
+            polygons = Polygons(
+                list(itertools.chain(*(area_polygon.as_wgs84_coordinates for area_polygon in areas_polygons)))
+            )
+
+        if area_attribute != "polygons" and len(self.areas) > 1:
+            # We’re combining simplified polygons from multiple areas so we
+            # need to re-simplify the combined polygons to keep the point
+            # count down
+            return polygons.smooth.simplify
+        return polygons
 
     def add_areas(self, *new_area_ids):
         self.area_ids = list(OrderedSet(self.area_ids + list(new_area_ids)))

--- a/app/models/broadcast_message.py
+++ b/app/models/broadcast_message.py
@@ -6,7 +6,7 @@ from flask_login import current_user
 from ordered_set import OrderedSet
 
 from app.broadcast_areas.models import BroadcastAreaLibraries, CustomBroadcastArea
-from app.broadcast_areas.utils import create_areas_dict
+from app.broadcast_areas.utils import aggregate_areas, generate_aggregate_names
 from app.models import ModelList
 from app.models.base_broadcast import BaseBroadcast
 from app.notify_client.broadcast_message_api_client import broadcast_message_api_client
@@ -79,15 +79,17 @@ class BroadcastMessage(BaseBroadcast):
     @classmethod
     def create_from_area(cls, service_id, area_ids, template_id=None, content="", reference=""):
         areas = BroadcastAreaLibraries().get_areas(area_ids)
-        areas_dict = create_areas_dict(areas)
-
+        aggregated_areas = aggregate_areas(areas)
+        aggregate_names = generate_aggregate_names(aggregated_areas)
+        areas = {
+            "ids": area_ids,
+            "names": [area.name for area in areas],
+            "aggregate_names": aggregate_names,
+            "simple_polygons": [area.simple_polygons.as_coordinate_pairs_lat_long for area in areas],
+        }
         return cls(
             broadcast_message_api_client.create_broadcast_message(
-                service_id=service_id,
-                template_id=template_id,
-                content=content,
-                reference=reference,
-                areas=areas_dict,
+                service_id=service_id, template_id=template_id, content=content, reference=reference, areas=areas
             )
         )
 

--- a/app/models/template.py
+++ b/app/models/template.py
@@ -3,7 +3,7 @@ from flask_login import current_user
 
 from app import current_service
 from app.broadcast_areas.models import BroadcastAreaLibraries, CustomBroadcastArea
-from app.broadcast_areas.utils import create_areas_dict
+from app.broadcast_areas.utils import aggregate_areas, generate_aggregate_names
 from app.models.base_broadcast import BaseBroadcast
 from app.notify_client.template_api_client import template_api_client
 
@@ -62,12 +62,19 @@ class Template(BaseBroadcast):
     @classmethod
     def create_from_area(cls, service_id, template_folder_id=None, area_ids=None):
         areas = BroadcastAreaLibraries().get_areas(area_ids)
-        areas_dict = create_areas_dict(areas)
+        aggregated_areas = aggregate_areas(areas)
+        aggregate_names = generate_aggregate_names(aggregated_areas)
+        areas = {
+            "ids": area_ids,
+            "names": [area.name for area in areas],
+            "aggregate_names": aggregate_names,
+            "simple_polygons": [area.simple_polygons.as_coordinate_pairs_lat_long for area in areas],
+        }
         return cls(
             template_api_client.create_template(
                 service_id=service_id,
                 template_folder_id=template_folder_id,
-                areas=areas_dict,
+                areas=areas,
             )
         )
 

--- a/tests/app/broadcast_areas/test_utils.py
+++ b/tests/app/broadcast_areas/test_utils.py
@@ -1,20 +1,13 @@
 import pytest
 
-from app.broadcast_areas.models import BroadcastAreaLibraries
-from app.broadcast_areas.utils import (
-    aggregate_areas,
-    create_areas_dict,
-    get_polygons_from_areas,
-)
+from app.broadcast_areas.utils import aggregate_areas
 from app.models.broadcast_message import BroadcastMessage
 from tests import broadcast_message_json
 from tests.app.broadcast_areas.custom_polygons import (
-    ABERDEEN_CITY,
     BRISTOL,
     BURFORD,
     CHELTENHAM,
     CHELTENHAM_AND_GLOUCESTER,
-    ENGLAND,
     SANTA_A,
     SEVERN_ESTUARY,
     SKYE,
@@ -201,47 +194,3 @@ def test_aggregate_areas_for_custom_polygons(
     )
 
     assert [area.name for area in aggregate_areas(broadcast_message.areas)] == expected_area_names
-
-
-@pytest.mark.parametrize(
-    ("area_ids", "expected_dict"),
-    [
-        (
-            ["ctry19-E92000001"],
-            {
-                "aggregate_names": ["England"],
-                "ids": ["ctry19-E92000001"],
-                "names": ["England"],
-                "simple_polygons": ENGLAND,
-            },
-        ),
-        (
-            ["lad23-S12000033"],
-            {
-                "aggregate_names": ["Aberdeen City"],
-                "ids": ["lad23-S12000033"],
-                "names": ["Aberdeen City"],
-                "simple_polygons": ABERDEEN_CITY,
-            },
-        ),
-        ([], {"aggregate_names": [], "ids": [], "names": [], "simple_polygons": []}),
-    ],
-)
-def test_create_areas_dict(area_ids, expected_dict):
-    areas = BroadcastAreaLibraries().get_areas(area_ids)
-    created_dict = create_areas_dict(areas)
-    assert created_dict == expected_dict
-
-
-@pytest.mark.parametrize(
-    ("area_ids", "area_attribute", "expected_polygons"),
-    [
-        (["ctry19-E92000001"], "simple_polygons", ENGLAND),
-        (["lad23-S12000033"], "simple_polygons", ABERDEEN_CITY),
-        ([], "simple_polygons", []),
-        (["nonexistent_area_id"], "simple_polygons", []),
-    ],
-)
-def test_get_polygons_from_areas(area_ids, area_attribute, expected_polygons):
-    areas = BroadcastAreaLibraries().get_areas(area_ids)
-    assert get_polygons_from_areas(areas, area_attribute).as_coordinate_pairs_lat_long == expected_polygons

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -8,7 +8,6 @@ import pytest
 from flask import url_for
 from freezegun import freeze_time
 
-from app.broadcast_areas.models import BroadcastAreaLibraries
 from tests import (
     NotifyBeautifulSoup,
     broadcast_message_json,
@@ -2151,9 +2150,9 @@ def test_add_broadcast_area(
     polygon_class = namedtuple("polygon_class", ["as_coordinate_pairs_lat_long"])
     coordinates = [[50.1, 0.1], [50.2, 0.2], [50.3, 0.2]]
     polygons = polygon_class(as_coordinate_pairs_lat_long=coordinates)
-    areas = BroadcastAreaLibraries().get_areas(["ctry19-E92000001", "ctry19-W92000004"])
     mock_get_polygons_from_areas = mocker.patch(
-        "app.models.base_broadcast.get_polygons_from_areas", return_value=polygons
+        "app.models.broadcast_message.BroadcastMessage.get_polygons_from_areas",
+        return_value=polygons,
     )
     mock_get_broadcast_message = mocker.patch(
         "app.broadcast_message_api_client.get_broadcast_message",
@@ -2181,7 +2180,7 @@ def test_add_broadcast_area(
         library_slug="ctry19",
         _data={"areas": ["ctry19-E92000001", "ctry19-W92000004"]},
     )
-    mock_get_polygons_from_areas.assert_called_once_with(areas, area_attribute="simple_polygons")
+    mock_get_polygons_from_areas.assert_called_once_with(area_attribute="simple_polygons")
     mock_get_broadcast_message.assert_called_once_with(service_id=SERVICE_ONE_ID, broadcast_message_id=fake_uuid)
 
     mock_update_broadcast_message_kwargs = mock_update_broadcast_message.call_args.kwargs
@@ -3392,7 +3391,8 @@ def test_add_broadcast_sub_area_district_view(
     coordinates = [[50.1, 0.1], [50.2, 0.2], [50.3, 0.2]]
     polygons = polygon_class(as_coordinate_pairs_lat_long=coordinates)
     mock_get_polygons_from_areas = mocker.patch(
-        "app.models.base_broadcast.get_polygons_from_areas", return_value=polygons
+        "app.models.broadcast_message.BroadcastMessage.get_polygons_from_areas",
+        return_value=polygons,
     )
 
     client_request.login(active_user_create_broadcasts_permission)
@@ -3411,12 +3411,7 @@ def test_add_broadcast_sub_area_district_view(
     expected_data["names"] = ["England", "Scotland"] + expected_data["names"]
     expected_data["aggregate_names"] = sorted(["England", "Scotland"] + expected_data["aggregate_names"])
 
-    # Asserting that the polygons created are created from all of the areas
-    areas = BroadcastAreaLibraries().get_areas(expected_data["ids"])
-    mock_get_polygons_from_areas_kwargs = mock_get_polygons_from_areas.call_args
-    assert sorted(mock_get_polygons_from_areas_kwargs[0][0]) == sorted(areas)
-    assert mock_get_polygons_from_areas_kwargs[1] == {"area_attribute": "simple_polygons"}
-
+    mock_get_polygons_from_areas.assert_called_once_with(area_attribute="simple_polygons")
     mock_update_broadcast_message_kwargs = mock_update_broadcast_message.call_args.kwargs
     assert mock_update_broadcast_message_kwargs["service_id"] == SERVICE_ONE_ID
     assert mock_update_broadcast_message_kwargs["broadcast_message_id"] == fake_uuid
@@ -3442,9 +3437,9 @@ def test_add_broadcast_sub_area_county_view(
     polygon_class = namedtuple("polygon_class", ["as_coordinate_pairs_lat_long"])
     coordinates = [[50.1, 0.1], [50.2, 0.2], [50.3, 0.2]]
     polygons = polygon_class(as_coordinate_pairs_lat_long=coordinates)
-    areas = BroadcastAreaLibraries().get_areas(["ctry19-E92000001", "ctry19-S92000003", "ctyua23-E10000016"])
     mock_get_polygons_from_areas = mocker.patch(
-        "app.models.base_broadcast.get_polygons_from_areas", return_value=polygons
+        "app.models.broadcast_message.BroadcastMessage.get_polygons_from_areas",
+        return_value=polygons,
     )
 
     client_request.login(active_user_create_broadcasts_permission)
@@ -3457,7 +3452,7 @@ def test_add_broadcast_sub_area_county_view(
         message_type="broadcast",
         _data={"select_all": "y"},
     )
-    mock_get_polygons_from_areas.assert_called_once_with(areas, area_attribute="simple_polygons")
+    mock_get_polygons_from_areas.assert_called_once_with(area_attribute="simple_polygons")
     mock_update_broadcast_message_kwargs = mock_update_broadcast_message.call_args.kwargs
     assert mock_update_broadcast_message_kwargs["service_id"] == SERVICE_ONE_ID
     assert mock_update_broadcast_message_kwargs["broadcast_message_id"] == fake_uuid
@@ -3494,9 +3489,9 @@ def test_remove_area_page(
     polygon_class = namedtuple("polygon_class", ["as_coordinate_pairs_lat_long"])
     coordinates = [[50.1, 0.1], [50.2, 0.2], [50.3, 0.2]]
     polygons = polygon_class(as_coordinate_pairs_lat_long=coordinates)
-    areas = BroadcastAreaLibraries().get_areas(["ctry19-S92000003"])
     mock_get_polygons_from_areas = mocker.patch(
-        "app.models.base_broadcast.get_polygons_from_areas", return_value=polygons
+        "app.models.broadcast_message.BroadcastMessage.get_polygons_from_areas",
+        return_value=polygons,
     )
 
     client_request.login(active_user_create_broadcasts_permission)
@@ -3510,7 +3505,7 @@ def test_remove_area_page(
             ".preview_areas", service_id=SERVICE_ONE_ID, message_id=fake_uuid, message_type="broadcast"
         ),
     )
-    mock_get_polygons_from_areas.assert_called_once_with(areas, area_attribute="simple_polygons")
+    mock_get_polygons_from_areas.assert_called_once_with(area_attribute="simple_polygons")
     mock_update_broadcast_message.assert_called_once_with(
         service_id=SERVICE_ONE_ID,
         broadcast_message_id=fake_uuid,

--- a/tests/app/models/test_broadcast_message.py
+++ b/tests/app/models/test_broadcast_message.py
@@ -164,7 +164,7 @@ def test_create_from_area(mocker, service_one, fake_uuid, mock_create_broadcast_
         content="Test content",
         areas={
             "ids": ["ctry19-E92000001"],
-            "simple_polygons": ENGLAND,
+            "simple_polygons": [ENGLAND],
             "names": ["England"],
             "aggregate_names": ["England"],
         },

--- a/tests/app/models/test_template.py
+++ b/tests/app/models/test_template.py
@@ -46,7 +46,7 @@ def test_create_template_from_area(mocker, fake_uuid, mock_create_template):
         service_id=SERVICE_ONE_ID,
         areas={
             "ids": ["ctry19-E92000001"],
-            "simple_polygons": ENGLAND,
+            "simple_polygons": [ENGLAND],
             "names": ["England"],
             "aggregate_names": ["England"],
         },


### PR DESCRIPTION
This reverts commit 55b40fa2c82a6ba18e1c14ccbf7f9cd925ee1ee2, as we need more time to test the change within the environments and reverting for now means avoiding blocking further deployments.