### PR TITLE
EAS-2898 Bump versions of pytest and related packages

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,38 +1,38 @@
 # Run `make freeze-requirements` to update requirements.txt
 # with package version changes made in requirements-app.txt
 
-humanize==4.4.0
-Flask==3.0.2
-Flask-WTF==1.2.1
-wtforms==3.1.2
+blinker==1.7.0
+fido2==1.2.0
 Flask-Login==0.6.3
-Werkzeug==3.1.3
+Flask-WTF==1.2.1
+Flask==3.0.2
+govuk-bank-holidays==0.15
+govuk-frontend-jinja==3.3.0
+humanize==4.4.0
+itsdangerous==2.1.2
 jinja2==3.1.6
 MarkupSafe==2.1.5
-blinker==1.7.0
-pytz==2022.6
 notifications-python-client==8.0.0
-rtreelib==0.2.0
-fido2==1.2.0
-pyproj==3.6.1
 postcode-validator==0.0.4
 pwdpy==1.0.1
-itsdangerous==2.1.2
-govuk-frontend-jinja==3.3.0
-govuk-bank-holidays==0.15
+pyproj==3.6.1
+pytz==2022.6
+rtreelib==0.2.0
 shapely==2.1.1
+Werkzeug==3.1.3
+wtforms==3.1.2
 
 # Packages for testing
-black==25.1.0
-isort==5.12.0
-pytest==8.3.5
-pytest-env==1.1.5
-pytest-mock==3.14.0
-pytest-xdist==3.6.1
 beautifulsoup4==4.11.1
-freezegun==1.2.2
-flake8==7.0.0
+black==25.1.0
 flake8-bugbear==22.10.27
 flake8-print==5.0.0
+flake8==7.0.0
+freezegun==1.2.2
+isort==5.12.0
 moto==5.1.3
+pytest-env==1.2.0
+pytest-mock==3.15.1
+pytest-xdist==3.8.0
+pytest==9.0.1
 requests-mock==1.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -128,21 +128,23 @@ pycparser==2.22
     # via cffi
 pyflakes==3.2.0
     # via flake8
+pygments==2.19.2
+    # via pytest
 pyjwt==2.10.1
     # via notifications-python-client
 pyproj==3.6.1
     # via -r requirements.in
-pytest==8.3.5
+pytest==9.0.1
     # via
     #   -r requirements.in
     #   pytest-env
     #   pytest-mock
     #   pytest-xdist
-pytest-env==1.1.5
+pytest-env==1.2.0
     # via -r requirements.in
-pytest-mock==3.14.0
+pytest-mock==3.15.1
     # via -r requirements.in
-pytest-xdist==3.6.1
+pytest-xdist==3.8.0
     # via -r requirements.in
 python-dateutil==2.9.0.post0
     # via


### PR DESCRIPTION
Updated packages and their new versions:

- pytest-env==1.2.0
- pytest-mock==3.15.1
- pytest-xdist==3.8.0
- pytest==9.0.1