### PR TITLE
EAS-2861: Admin: Source API_HOST_NAME and ADMIN_EXTERNAL_URL directly if present

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -177,10 +177,10 @@ def create_app(application):
 def init_app(application):
     application.after_request(useful_headers_after_request)
 
+    application.before_request(generate_nonce_before_request)
     application.before_request(load_service_before_request)
     application.before_request(load_organisation_before_request)
     application.before_request(load_service_status_before_request)
-    application.before_request(generate_nonce_before_request)
     application.before_request(request_helper.check_proxy_header_before_request)
 
     font_paths = [

--- a/app/config.py
+++ b/app/config.py
@@ -32,9 +32,6 @@ class Config(object):
 
     GEOJSON_BUCKET = os.environ.get("POSTCODE_BUCKET_NAME")
 
-    # if we're not on cloudfoundry, we can get to this app from localhost. but on cloudfoundry its different
-    ADMIN_BASE_URL = os.environ.get("ADMIN_BASE_URL", "http://localhost:6012")
-
     TEMPLATE_PREVIEW_API_HOST = os.environ.get("TEMPLATE_PREVIEW_API_HOST", "http://localhost:6013")
     TEMPLATE_PREVIEW_API_KEY = os.environ.get("TEMPLATE_PREVIEW_API_KEY", "my-secret-key")
 
@@ -116,10 +113,11 @@ class Hosted(Config):
         if os.environ.get("ENVIRONMENT") == "development"
         else f"{os.environ.get('ENVIRONMENT')}." if os.environ.get("ENVIRONMENT") != "production" else ""
     )
-    API_HOST_NAME = f"http://api.{TENANT}ecs.local:6011"
-    ADMIN_BASE_URL = f"http://admin.{TENANT}ecs.local:6012"
+    API_HOST_NAME = os.environ.get("API_HOST_NAME", f"http://api.{TENANT}ecs.local:6011")
     HEADER_COLOUR = header_colors.get(os.environ.get("ENVIRONMENT"), "#81878b")
-    ADMIN_EXTERNAL_URL = f"https://{TENANT}admin.{SUBDOMAIN}emergency-alerts.service.gov.uk"
+    ADMIN_EXTERNAL_URL = os.environ.get(
+        "ADMIN_EXTERNAL_URL", f"https://{TENANT}admin.{SUBDOMAIN}emergency-alerts.service.gov.uk"
+    )
     TEMPLATE_PREVIEW_API_HOST = f"http://api.{TENANT}ecs.local:6013"
 
     DEBUG = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1374,7 +1374,6 @@ def set_config_values(app, dict):
 def webauthn_dev_server(notify_admin, mocker):
     overrides = {
         "HOST": "local",
-        "ADMIN_BASE_URL": "https://webauthn.io",
         "ADMIN_EXTERNAL_URL": "https://webauthn.io",
     }
 


### PR DESCRIPTION
This is to enable breaking out of the mould (e.g. my upcoming localenv rework) without having an assumption on GovUK specifics.

This should transparently fallback to the logic we have today. Though I have removed `ADMIN_BASE_URL` as it seemed unused.