### PR TITLE
Updating versions of urllib3 and werkzeug

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -20,8 +20,8 @@ pyproj==3.6.1
 pytz==2022.6
 rtreelib==0.2.0
 shapely==2.1.1
-urllib3==2.6.2
-Werkzeug==3.1.3
+urllib3==2.6.3
+Werkzeug==3.1.5
 wtforms==3.1.2
 
 # Packages for testing

--- a/requirements.txt
+++ b/requirements.txt
@@ -508,13 +508,13 @@ typing-extensions==4.15.0
     # via
     #   grpcio
     #   opentelemetry-sdk
-urllib3==2.6.2
+urllib3==2.6.3
     # via
     #   -r requirements.in
     #   botocore
     #   requests
     #   responses
-werkzeug==3.1.3
+werkzeug==3.1.5
     # via
     #   -r requirements.in
     #   flask


### PR DESCRIPTION
Updating `urllib3` and `Werkzeug` package versions, as recommended by scan findings, to remediate [CVE-2026-21441](https://nvd.nist.gov/vuln/detail/CVE-2026-21441) and [CVE-2026-21860](https://nvd.nist.gov/vuln/detail/CVE-2026-21860) respectively. 