### PR TITLE
EAS-2956: Admin: Restrict PR CI permissions to read

### DIFF
--- a/.github/workflows/on-pr-into-main.yml
+++ b/.github/workflows/on-pr-into-main.yml
@@ -1,5 +1,8 @@
 name: on-pr-into-main
 
+permissions:
+  contents: read
+
 env:
   PYTHON_VERSION: 3.12
 


### PR DESCRIPTION
Fixes https://github.com/alphagov/emergency-alerts-admin/security/code-scanning/1