### PR TITLE
Refine selector allow opt-in to clear-all behaviour

### DIFF
--- a/app/assets/javascripts/clearCheckboxesOnShowAndLoad.js
+++ b/app/assets/javascripts/clearCheckboxesOnShowAndLoad.js
@@ -2,7 +2,7 @@
   "use strict";
   window.GOVUK.clearCheckboxesOnShowAndLoad = () => {
     function clearCheckboxes() {
-      const checkboxes = document.querySelectorAll('input[type="checkbox"]');
+      const checkboxes = document.querySelectorAll('input[type="checkbox"].clear-on-reload');
       if (checkboxes.length) {
         for (const checkbox of checkboxes) {
           checkbox.checked = false;

--- a/app/templates/views/broadcast/draft-broadcasts.html
+++ b/app/templates/views/broadcast/draft-broadcasts.html
@@ -21,7 +21,7 @@
           {% for item in sorted_broadcasts %}
             <div class="keyline-block">
               <div class="govuk-checkboxes__item template-list-item template-list-item-with-checkbox template-list-item-without-ancestors">
-                <input class="govuk-checkboxes__input" id="{{ item.id }}" name="checked_alerts" type="checkbox" value="{{ item.id }}">
+                <input class="govuk-checkboxes__input clear-on-reload" id="{{ item.id }}" name="checked_alerts" type="checkbox" value="{{ item.id }}">
                 <label class="govuk-label govuk-checkboxes__label template-list-item-label" for="{{ item.id }}">
                   <span class="govuk-visually-hidden">
                     {{ item.reference or item.template_name or "Untitled alert"}}

--- a/tests/javascripts/clearCheckboxesOnShowAndLoad.test.js
+++ b/tests/javascripts/clearCheckboxesOnShowAndLoad.test.js
@@ -9,9 +9,9 @@ afterAll(() => {
 const htmlContent = `
 <main>
   <form id="test-form">
-    <input type="checkbox" id="checkbox1" checked>
-    <input type="checkbox" id="checkbox2" checked>
-    <input type="checkbox" id="checkbox3">
+    <input class="clear-on-reload" type="checkbox" id="checkbox1" checked>
+    <input class="clear-on-reload" type="checkbox" id="checkbox2" checked>
+    <input class="clear-on-reload" type="checkbox" id="checkbox3">
     <input type="text" id="textfield" value="test">
   </form>
 </main>
@@ -54,26 +54,26 @@ describe("Function clearCheckboxesOnShowAndLoad", () => {
     expect(mockCheckbox2.checked).toBe(false);
   });
 
-  // test('should clear all checkboxes on load event', () => {
-  //   window.GOVUK.clearCheckboxesOnShowAndLoad();
+  test('should clear all checkboxes on load event', () => {
+    window.GOVUK.clearCheckboxesOnShowAndLoad();
 
-  //   // Get the load event handler
-  //   const loadHandler = addEventListenerSpy.mock.calls.find(
-  //     call => call[0] === 'load'
-  //   )[1];
+    // Get the load event handler
+    const loadHandler = addEventListenerSpy.mock.calls.find(
+      call => call[0] === 'load'
+    )[1];
 
-  //   let mockCheckbox1 = document.getElementById("checkbox1");
-  //   let mockCheckbox2 = document.getElementById("checkbox2");
+    let mockCheckbox1 = document.getElementById("checkbox1");
+    let mockCheckbox2 = document.getElementById("checkbox2");
 
-  //   // Verify checkboxes are checked before event
-  //   expect(mockCheckbox1.checked).toBe(true);
-  //   expect(mockCheckbox2.checked).toBe(true);
+    // Verify checkboxes are checked before event
+    expect(mockCheckbox1.checked).toBe(true);
+    expect(mockCheckbox2.checked).toBe(true);
 
-  //   // Trigger the load event handler
-  //   loadHandler();
+    // Trigger the load event handler
+    loadHandler();
 
-  //   // Verify checkboxes are unchecked after event
-  //   expect(mockCheckbox1.checked).toBe(false);
-  //   expect(mockCheckbox2.checked).toBe(false);
-  // });
+    // Verify checkboxes are unchecked after event
+    expect(mockCheckbox1.checked).toBe(false);
+    expect(mockCheckbox2.checked).toBe(false);
+  });
 });


### PR DESCRIPTION
Draft-deletion required javascript to clear checkboxes to prevent spurious checkbox selection when the forward/back browser buttons were used to navigate.
This behaviour should require the templates to opt-in to this functionality, hence the addition of a 'clear-on-reload' class.