### PR TITLE
EAS-2910: Fix filter options mixing order between requests

### DIFF
--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -227,7 +227,7 @@ def _persist_and_return_filter_and_sort_values(page):
 
 
 def _get_filter_options(broadcast_messages, filter=None, page="current-alerts"):
-    statuses = list(set(msg.status for msg in broadcast_messages))
+    statuses = sorted(list(set(msg.status for msg in broadcast_messages)))
     filter_options = [{"value": status, "text": FILTER_TEXT[status]} for status in statuses]
     if len(filter_options) > 1:
         filter_options.insert(0, {"value": "none", "text": "All Alerts"})


### PR DESCRIPTION
This fixes the minor glitch where the dropdown options would randomly jumble up in order while on the alerts page, exacerbated by the regular AJAX requests that redraw the page content for new alerts. It's just a side effect of sets having no concept of a stable ordering.

<img width="249" height="250" alt="image" src="https://github.com/user-attachments/assets/60cf5b9c-7de8-4d52-bb80-70e11bbbdd79" />
