### PR TITLE
EAS-2783: Only redirect to manage users after approving admin action if elevated

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
-venv
+venv/
+node_modules/
 .git
 .env
 .envrc

--- a/app/utils/admin_action.py
+++ b/app/utils/admin_action.py
@@ -58,7 +58,7 @@ def process_admin_action(action_obj):
             action_data["folder_permissions"],
         )
         flash("Sent invite to user " + action_data["email_address"], "default_with_tick")
-        return redirect(url_for(".manage_users", service_id=service_id))
+        return _redirect_manage_users_or_admin_action(service_id)
     elif action_type == ADMIN_EDIT_PERMISSIONS:
         user = User.from_id(action_data["user_id"])
         user.set_permissions(
@@ -68,7 +68,7 @@ def process_admin_action(action_obj):
             set_by_id=current_user.id,
         )
         flash("Updated permissions for " + user.email_address, "default_with_tick")
-        return redirect(url_for(".manage_users", service_id=service_id))
+        return _redirect_manage_users_or_admin_action(service_id)
     elif action_type == ADMIN_CREATE_API_KEY:
         service = Service.from_id(service_id)
         if service.trial_mode and action_data["key_type"] == KEY_TYPE_NORMAL:
@@ -76,7 +76,8 @@ def process_admin_action(action_obj):
         secret = api_key_api_client.create_api_key(
             service_id=service_id, key_name=action_data["key_name"], key_type=action_data["key_type"]
         )
-        # The template uses has_permissions and requires the service ID to be in the request args
+        # The template uses a parent tamplate that uses has_permissions and requires the service
+        # ID to be in the request args
         request.view_args["service_id"] = service_id
         return render_template(
             "views/api/keys/show.html",
@@ -333,3 +334,19 @@ def _is_out_of_office_hours():
     if now.weekday() in [5, 6]:  # Saturday/Sunday
         return True
     return False
+
+
+def _redirect_manage_users_or_admin_action(service_id: str):
+    """
+    If we're elevated then we'll be able to view manage_users of the service.
+    However, if we're not, and we approve the admin action, we can't redirect
+    to the manage users page as we'll run into a forbidden error unless we're
+    part of the service as a user already.
+    """
+
+    can_view_manage_users = current_user.platform_admin or current_user.belongs_to_service(service_id)
+
+    if can_view_manage_users:
+        return redirect(url_for(".manage_users", service_id=service_id))
+    else:
+        return redirect(url_for(".admin_actions"))

--- a/tests/app/main/views/test_platform_admin.py
+++ b/tests/app/main/views/test_platform_admin.py
@@ -636,13 +636,20 @@ class TestPlatformAdminActions:
         clipboard = page.select_one(".copy-to-clipboard__value")
         assert "key-secret" in clipboard.text
 
+    @pytest.mark.parametrize("approver_is_platform_admin", [True, False])
     def test_approving_creates_user_invite(
         self,
         client_request,
         platform_admin_user,
         mock_admin_action_notification,
         mocker,
+        approver_is_platform_admin,
     ):
+        if not approver_is_platform_admin:
+            # User is platform admin capable only (not elevated)
+            # They can approve it, but likely don't have access to the service themselves
+            platform_admin_user["platform_admin_active"] = False
+
         action_or_creator_id = str(uuid.uuid4())
         mocker.patch(
             "app.admin_actions_api_client.get_admin_action_by_id",
@@ -674,7 +681,11 @@ class TestPlatformAdminActions:
             "main.review_admin_action",
             action_id=action_or_creator_id,
             new_status="approved",
-            _expected_redirect=url_for(".manage_users", service_id=SERVICE_ONE_ID),
+            _expected_redirect=(
+                url_for(".manage_users", service_id=SERVICE_ONE_ID)
+                if approver_is_platform_admin
+                else url_for(".admin_actions")
+            ),
         )
 
         mock_admin_action_notification.assert_called_once()
@@ -690,13 +701,20 @@ class TestPlatformAdminActions:
             [],
         )
 
+    @pytest.mark.parametrize("approver_is_platform_admin", [True, False])
     def test_approving_edits_user_permissions(
         self,
         client_request,
         platform_admin_user,
         mock_admin_action_notification,
         mocker,
+        approver_is_platform_admin,
     ):
+        if not approver_is_platform_admin:
+            # User is platform admin capable only (not elevated)
+            # They can approve it, but likely don't have access to the service themselves
+            platform_admin_user["platform_admin_active"] = False
+
         action_or_creator_id = str(uuid.uuid4())
         edited_user_id = str(uuid.uuid4())
 
@@ -735,7 +753,11 @@ class TestPlatformAdminActions:
             "main.review_admin_action",
             action_id=action_or_creator_id,
             new_status="approved",
-            _expected_redirect=url_for(".manage_users", service_id=SERVICE_ONE_ID),
+            _expected_redirect=(
+                url_for(".manage_users", service_id=SERVICE_ONE_ID)
+                if approver_is_platform_admin
+                else url_for(".admin_actions")
+            ),
         )
 
         mock_admin_action_notification.assert_called_once()

--- a/tests/app/utils/test_admin_action.py
+++ b/tests/app/utils/test_admin_action.py
@@ -16,6 +16,9 @@ from app.utils.admin_action import (
 )
 from tests.conftest import SERVICE_ONE_ID, USER_ONE_ID, set_config
 
+# These tests concern the utils - except 'doing' things with AdminActions
+# See TestPlatformAdminActions in test_platform_admin for that
+
 
 @pytest.mark.parametrize(
     "existing_actions, proposed_action_obj, expect_invalidation",


### PR DESCRIPTION
This hotfixes approving admin actions. This logic was written before admin elevation came to be, and thus it was assumed anyone approving admin actions would be in an elevated state and have read-only access to the whole system.

This isn't true these days: any platform admin _capable_ user can approve actions, but redirecting them to the 'manage users' page of a service to invite/edit a user won't necessarily work.

We now verify if the user has the ability to view the service in their current state, and otherwise just redirect back to the approvals page if they don't. This is much better than a 403 error.