### PR TITLE
EAS-2884: Admin: Present per-operator sending statuses and sending error tag

### DIFF
--- a/app/assets/stylesheets/govuk-frontend/overrides.scss
+++ b/app/assets/stylesheets/govuk-frontend/overrides.scss
@@ -90,7 +90,8 @@ $notify-secondary-button-hover-colour: govuk-shade(govuk-colour("light-grey"), 1
 
 .govuk-tag.failed-sending-tag {
   @include govuk-tag-uppercase;
-  background-color: govuk-colour("orange");
+  background-color: govuk-colour("yellow");
+  color: black;
 }
 
 .govuk-tabs {

--- a/app/assets/stylesheets/govuk-frontend/overrides.scss
+++ b/app/assets/stylesheets/govuk-frontend/overrides.scss
@@ -91,7 +91,7 @@ $notify-secondary-button-hover-colour: govuk-shade(govuk-colour("light-grey"), 1
 .govuk-tag.failed-sending-tag {
   @include govuk-tag-uppercase;
   background-color: govuk-colour("yellow");
-  color: black;
+  color: govuk-colour("black");
 }
 
 .govuk-tabs {

--- a/app/assets/stylesheets/govuk-frontend/overrides.scss
+++ b/app/assets/stylesheets/govuk-frontend/overrides.scss
@@ -88,6 +88,11 @@ $notify-secondary-button-hover-colour: govuk-shade(govuk-colour("light-grey"), 1
   background-color: govuk-colour("orange");
 }
 
+.govuk-tag.failed-sending-tag {
+  @include govuk-tag-uppercase;
+  background-color: govuk-colour("orange");
+}
+
 .govuk-tabs {
   overflow-wrap: break-word;
 }

--- a/app/config.py
+++ b/app/config.py
@@ -1,4 +1,5 @@
 import os
+from dataclasses import dataclass
 
 header_colors = {
     "local": "#FF8000",
@@ -9,11 +10,18 @@ header_colors = {
 }
 
 
+@dataclass
+class BroadcastProviderDefinition:
+    name: str
+    human_name: str
+
+
 class BroadcastProvider:
-    EE = "ee"
-    VODAFONE = "vodafone"
-    THREE = "three"
-    O2 = "o2"
+    EE = BroadcastProviderDefinition("ee", "EE")
+    VODAFONE = BroadcastProviderDefinition("vodafone", "Vodafone")
+    THREE = BroadcastProviderDefinition("three", "Three")
+    O2 = BroadcastProviderDefinition("o2", "O2")
+
     PROVIDERS = [EE, O2, THREE, VODAFONE]
 
 

--- a/app/formatters.py
+++ b/app/formatters.py
@@ -331,10 +331,11 @@ def character_count(count):
 
 def format_mobile_networks(networks):
     if isinstance(networks, str):
-        return networks.capitalize()
+        networks = [networks]
 
     if not isinstance(networks, list):
         return None
+
     network_list = []
     for network in networks:
         if network in ("three", "vodafone", "o2"):

--- a/app/formatters.py
+++ b/app/formatters.py
@@ -161,9 +161,9 @@ def format_date_human(date):
     return get_human_day(date)
 
 
-def format_datetime_human(date, date_prefix=""):
+def format_datetime_human(date, date_prefix="on"):
     return "{} at {}".format(
-        get_human_day(date, date_prefix="on"),
+        get_human_day(date, date_prefix=date_prefix),
         format_time(date),
     )
 
@@ -406,3 +406,17 @@ def split_text_by_comma_and_newline(input):
 
 def split_text_by_newline(input):
     return [item.strip() for item in re.split(r"[\n]+", input) if item.strip()]
+
+
+def format_provider_status_with_human_time(status, date):
+    status_mapping = {
+        "technical-failure": "Failed ",  # Unused as of writing
+        "sending": "Sending ",
+        "returned-ack": "Sent ",
+        "returned-error": "Failed ",
+    }
+
+    # Say "sending since"
+    date_prefix = "on" if not status == "sending" else "since"
+
+    return status_mapping.get(status, f"(Unknown status {status}) ") + format_datetime_human(date, date_prefix)

--- a/app/formatters.py
+++ b/app/formatters.py
@@ -51,7 +51,7 @@ def format_datetime_normal(date):
 
 
 def format_datetime_short(date):
-    return "{} at {}".format(format_date_short(date), format_time(date))
+    return "{} at {}".format(format_date_short(date), format_time(date, include_seconds=True))
 
 
 def format_datetime_relative(date):
@@ -134,12 +134,13 @@ def get_human_day(time, date_prefix=""):
     ).strip()
 
 
-def format_time(date):
+def format_time(date, include_seconds=False):
+    format = "%-I:%M:%S%p" if include_seconds else "%-I:%M%p"
     return (
         {"12:00AM": "Midnight", "12:00PM": "Midday"}
         .get(
-            utc_string_to_aware_gmt_datetime(date).strftime("%-I:%M%p"),
-            utc_string_to_aware_gmt_datetime(date).strftime("%-I:%M%p"),
+            utc_string_to_aware_gmt_datetime(date).strftime(format),
+            utc_string_to_aware_gmt_datetime(date).strftime(format),
         )
         .lower()
     )
@@ -164,7 +165,7 @@ def format_date_human(date):
 def format_datetime_human(date, date_prefix="on"):
     return "{} at {}".format(
         get_human_day(date, date_prefix=date_prefix),
-        format_time(date),
+        format_time(date, include_seconds=True),
     )
 
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1714,20 +1714,14 @@ class ServiceBroadcastNetworkForm(StripWhitespaceForm):
 
     networks = GovukCheckboxesFieldWithNetworkRequired(
         None,
-        choices=[
-            ("all", "All mobile networks"),
-            ("ee", "EE"),
-            ("o2", "O2"),
-            ("three", "Three"),
-            ("vodafone", "Vodafone"),
-        ],
+        choices=[("all", "All mobile networks")] + [(p.name, p.human_name) for p in BroadcastProvider.PROVIDERS],
         param_extensions={"hint": None, "fieldset": {"legend": {"classes": "govuk-visually-hidden"}}},
     )
 
     @property
     def account_type(self):
         if "all" in self.networks.data:
-            providers = "-".join(BroadcastProvider.PROVIDERS)
+            providers = "-".join([p.name for p in BroadcastProvider.PROVIDERS])
         else:
             providers = "-".join(self.networks.data)
 

--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -152,9 +152,19 @@ def broadcast_dashboard_previous(service_id):
     ]
     filtered_broadcasts = _filter_broadcasts(broadcast_messages, filter)
     filtered_and_sorted_broadcasts = _sort_broadcasts(filtered_broadcasts, sort)
+
+    # Loop through every broadcast message and find any which have a latest provider status for any
+    # MNO of `returned-error`
+    failed_broadcast_ids = set()
+    for broadcast_message in filtered_and_sorted_broadcasts:
+        provider_statuses = broadcast_message.get_broadcast_provider_statuses()
+        if provider_statuses_contains_fail_to_send(provider_statuses):
+            failed_broadcast_ids.add(broadcast_message.id)
+
     return render_template(
         "views/broadcast/previous-broadcasts.html",
         broadcasts=filtered_and_sorted_broadcasts,
+        failed_broadcast_ids=failed_broadcast_ids,
         page_title="Past alerts",
         empty_message="You do not have any past alerts",
         view_broadcast_endpoint=".view_previous_broadcast",

--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -219,6 +219,8 @@ def get_broadcast_dashboard_partials(service_id):
     # MNO of `returned-error`
     failed_broadcast_ids = set()
     for broadcast_message in filtered_and_sorted_broadcasts:
+        if broadcast_message.status != "broadcasting":
+            continue  # Skip requesting for something that's not sent
         provider_statuses = broadcast_message.get_broadcast_provider_statuses()
         if provider_statuses_contains_fail_to_send(provider_statuses):
             failed_broadcast_ids.add(broadcast_message.id)

--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -39,6 +39,7 @@ from app.utils import service_has_permission
 from app.utils.broadcast import (
     INVALID_AREA_ERROR_TEXT,
     _get_back_link_from_view_broadcast_endpoint,
+    _provider_statuses_contains_fail_to_send,
     check_for_missing_fields,
     format_areas_list,
     get_alert_redirect_url,
@@ -204,19 +205,13 @@ def get_broadcast_dashboard_partials(service_id):
     filtered_broadcasts = _filter_broadcasts(broadcast_messages, filter)
     filtered_and_sorted_broadcasts = _sort_broadcasts(filtered_broadcasts, sort)
 
-    failed_broadcast_ids = set()
     # Loop through every broadcast message and find any which have a latest provider status for any
     # MNO of `returned-error`
+    failed_broadcast_ids = set()
     for broadcast_message in filtered_and_sorted_broadcasts:
         provider_statuses = broadcast_message.get_broadcast_provider_statuses()
-
-        for mno in provider_statuses:
-            alert_statuses = provider_statuses[mno].get("alert", [])
-            if len(alert_statuses) > 0:
-                latest_alert_status = alert_statuses[-1]
-                if latest_alert_status["status"] == "returned-error":
-                    failed_broadcast_ids.add(broadcast_message.id)
-                    break
+        if _provider_statuses_contains_fail_to_send(provider_statuses):
+            failed_broadcast_ids.add(broadcast_message.id)
 
     return dict(
         current_broadcasts=render_template(

--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -203,10 +203,26 @@ def get_broadcast_dashboard_partials(service_id):
     ]
     filtered_broadcasts = _filter_broadcasts(broadcast_messages, filter)
     filtered_and_sorted_broadcasts = _sort_broadcasts(filtered_broadcasts, sort)
+
+    failed_broadcast_ids = set()
+    # Loop through every broadcast message and find any which have a latest provider status for any
+    # MNO of `returned-error`
+    for broadcast_message in filtered_and_sorted_broadcasts:
+        provider_statuses = broadcast_message.get_broadcast_provider_statuses()
+
+        for mno in provider_statuses:
+            alert_statuses = provider_statuses[mno].get("alert", [])
+            if len(alert_statuses) > 0:
+                latest_alert_status = alert_statuses[-1]
+                if latest_alert_status["status"] == "returned-error":
+                    failed_broadcast_ids.add(broadcast_message.id)
+                    break
+
     return dict(
         current_broadcasts=render_template(
             "views/broadcast/partials/dashboard-table.html",
             broadcasts=filtered_and_sorted_broadcasts,
+            failed_broadcast_ids=failed_broadcast_ids,
             selects=selects,
             empty_message="You do not have any current alerts",
             view_broadcast_endpoint=".view_current_broadcast",

--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -39,7 +39,6 @@ from app.utils import service_has_permission
 from app.utils.broadcast import (
     INVALID_AREA_ERROR_TEXT,
     _get_back_link_from_view_broadcast_endpoint,
-    _provider_statuses_contains_fail_to_send,
     check_for_missing_fields,
     format_areas_list,
     get_alert_redirect_url,
@@ -49,6 +48,7 @@ from app.utils.broadcast import (
     keep_alert_reference_button_clicked,
     overwrite_content_button_clicked,
     overwrite_reference_button_clicked,
+    provider_statuses_contains_fail_to_send,
     redirect_if_operator_service,
     render_current_alert_page,
     render_edit_alert_page,
@@ -210,7 +210,7 @@ def get_broadcast_dashboard_partials(service_id):
     failed_broadcast_ids = set()
     for broadcast_message in filtered_and_sorted_broadcasts:
         provider_statuses = broadcast_message.get_broadcast_provider_statuses()
-        if _provider_statuses_contains_fail_to_send(provider_statuses):
+        if provider_statuses_contains_fail_to_send(provider_statuses):
             failed_broadcast_ids.add(broadcast_message.id)
 
     return dict(

--- a/app/models/broadcast_message.py
+++ b/app/models/broadcast_message.py
@@ -292,6 +292,9 @@ class BroadcastMessage(BaseBroadcast):
         table for the broadcast_message_id"""
         return broadcast_message_api_client.get_latest_returned_for_edit_reason(self.service_id, self.id)
 
+    def get_broadcast_provider_statuses(self):
+        return broadcast_message_api_client.get_broadcast_provider_statuses(self.service_id, self.id)
+
 
 class BroadcastMessages(ModelList):
     model = BroadcastMessage

--- a/app/notify_client/broadcast_message_api_client.py
+++ b/app/notify_client/broadcast_message_api_client.py
@@ -114,5 +114,12 @@ class BroadcastMessageAPIClient(AdminAPIClient):
             f"/service/{service_id}/broadcast-message-edit-reasons/{broadcast_message_id}/latest-edit-reason"
         )
 
+    def get_broadcast_provider_statuses(self, service_id, broadcast_message_id):
+        """
+        Retrieve all the broadcast provider statuses relating to the broadcast message
+        (including both alert and cancel events)
+        """
+        return self.get(f"/service/{service_id}/broadcast-message/{broadcast_message_id}/provider-statuses")
+
 
 broadcast_message_api_client = BroadcastMessageAPIClient()

--- a/app/templates/views/broadcast/partials/broadcast-details.html
+++ b/app/templates/views/broadcast/partials/broadcast-details.html
@@ -1,9 +1,9 @@
 {% from "govuk_frontend_jinja/components/tag/macro.html" import govukTag %}
 
-{% macro broadcast_details(broadcast_message, current_service, sending_failure=false) %}
+{% macro broadcast_details(broadcast_message, current_service, broadcast_provider_sending_failure=false) %}
 {% if broadcast_message.status == 'broadcasting' %}
 <p class="govuk-body govuk-!-margin-bottom-2 live-broadcast live-broadcast--left">
-  {% if sending_failure %}
+  {% if broadcast_provider_sending_failure %}
     {{ govukTag ({
       'text': 'sending error',
       'classes': 'govuk-!-margin-right-2 failed-sending-tag'
@@ -42,7 +42,7 @@
 {% endif %}
 {% else %}
 <p class="govuk-body govuk-!-margin-bottom-4">
-  {% if sending_failure %}
+  {% if broadcast_provider_sending_failure %}
     {{ govukTag ({
       'text': 'sending error',
       'classes': 'govuk-!-margin-right-2 failed-sending-tag'

--- a/app/templates/views/broadcast/partials/broadcast-details.html
+++ b/app/templates/views/broadcast/partials/broadcast-details.html
@@ -1,8 +1,14 @@
 {% from "govuk_frontend_jinja/components/tag/macro.html" import govukTag %}
 
-{% macro broadcast_details(broadcast_message, current_service) %}
+{% macro broadcast_details(broadcast_message, current_service, sending_failure=false) %}
 {% if broadcast_message.status == 'broadcasting' %}
 <p class="govuk-body govuk-!-margin-bottom-2 live-broadcast live-broadcast--left">
+  {% if sending_failure %}
+    {{ govukTag ({
+      'text': 'sending error',
+      'classes': 'govuk-!-margin-right-2 failed-sending-tag'
+    }) }}
+  {% endif %}
   {{ govukTag ({
     'text': 'live',
     'classes': 'govuk-!-margin-right-2 broadcast-tag'
@@ -36,6 +42,12 @@
 {% endif %}
 {% else %}
 <p class="govuk-body govuk-!-margin-bottom-4">
+  {% if sending_failure %}
+    {{ govukTag ({
+      'text': 'sending error',
+      'classes': 'govuk-!-margin-right-2 failed-sending-tag'
+    }) }}
+  {% endif %}
   Sent
   {{ broadcast_message.starts_at|format_datetime_human }}.
 </p>

--- a/app/templates/views/broadcast/partials/dashboard-table.html
+++ b/app/templates/views/broadcast/partials/dashboard-table.html
@@ -16,6 +16,10 @@
   {% endif %}
 
   {% for item in broadcasts %}
+    {% set sending_error = govukTag ({
+        'text': 'sending error',
+        'classes': 'govuk-!-margin-right-2 failed-sending-tag'
+      }) if item.id in failed_broadcast_ids else "" %}
     <div class="keyline-block">
       <div class="file-list file-list--sectioned govuk-!-margin-bottom-2">
         <h2>
@@ -44,6 +48,7 @@
           </span>
         {% elif item.status == 'broadcasting' %}
           <p class="govuk-body live-broadcast file-list-status">
+            {{ sending_error }}
             {{ govukTag ({
               'text': 'live',
               'classes': 'govuk-!-margin-right-2 broadcast-tag'
@@ -66,6 +71,7 @@
           </p>
         {% else %}
           <p class="govuk-body govuk-hint file-list-status">
+            {{ sending_error }}
             {{ item.starts_at|format_date_human|title }} at {{ item.starts_at|format_time }}
           </p>
         {% endif %}

--- a/app/templates/views/broadcast/partials/status-history.html
+++ b/app/templates/views/broadcast/partials/status-history.html
@@ -72,21 +72,24 @@
             </p>
         {% endif %}
 
-        {{ govukTable({
-            "caption": "Operator Statuses",
-            "firstCellIsHeader": true,
-            "head": [
-                {
-                    "text": "Operator"
-                },
-                {
-                    "text": "Alert Status",
-                },
-                {
-                    "text": "Cancellation Status",
-                }
-            ],
-            "rows": broadcast_provider_status_rows
-        }) }}
+        {% if broadcast_provider_status_rows %}
+            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+            {{ govukTable({
+                "caption": "Operator Statuses",
+                "firstCellIsHeader": true,
+                "head": [
+                    {
+                        "text": "Operator"
+                    },
+                    {
+                        "text": "Alert Status",
+                    },
+                    {
+                        "text": "Cancellation Status",
+                    }
+                ],
+                "rows": broadcast_provider_status_rows
+            }) }}
+        {% endif %}
 
 {% endmacro %}

--- a/app/templates/views/broadcast/partials/status-history.html
+++ b/app/templates/views/broadcast/partials/status-history.html
@@ -1,4 +1,6 @@
-{% macro broadcast_message_status_history(broadcast_message, edit_reasons) %}
+{% from "govuk_frontend_jinja/components/table/macro.html" import govukTable %}
+
+{% macro broadcast_message_status_history(broadcast_message, edit_reasons, broadcast_provider_status_rows) %}
         {% if broadcast_message.status == 'broadcasting' %}
             <p class="govuk-body govuk-!-margin-bottom-3">
                 Broadcasting stops {{ broadcast_message.finishes_at|format_datetime_human }}.
@@ -69,5 +71,22 @@
                 Finished broadcasting {{ broadcast_message.finishes_at|format_datetime_human }}.
             </p>
         {% endif %}
+
+        {{ govukTable({
+            "caption": "Broadcast Provider Statuses",
+            "firstCellIsHeader": true,
+            "head": [
+                {
+                    "text": "Provider"
+                },
+                {
+                    "text": "Alert",
+                },
+                {
+                    "text": "Cancellation",
+                }
+            ],
+            "rows": broadcast_provider_status_rows
+        }) }}
 
 {% endmacro %}

--- a/app/templates/views/broadcast/partials/status-history.html
+++ b/app/templates/views/broadcast/partials/status-history.html
@@ -73,17 +73,17 @@
         {% endif %}
 
         {{ govukTable({
-            "caption": "Broadcast Provider Statuses",
+            "caption": "Operator Statuses",
             "firstCellIsHeader": true,
             "head": [
                 {
-                    "text": "Provider"
+                    "text": "Operator"
                 },
                 {
-                    "text": "Alert",
+                    "text": "Alert Status",
                 },
                 {
-                    "text": "Cancellation",
+                    "text": "Cancellation Status",
                 }
             ],
             "rows": broadcast_provider_status_rows

--- a/app/templates/views/broadcast/partials/status-history.html
+++ b/app/templates/views/broadcast/partials/status-history.html
@@ -1,6 +1,6 @@
 {% from "govuk_frontend_jinja/components/table/macro.html" import govukTable %}
 
-{% macro broadcast_message_status_history(broadcast_message, edit_reasons, broadcast_provider_status_rows) %}
+{% macro broadcast_message_status_history(broadcast_message, edit_reasons, broadcast_provider_status_rows, broadcast_provider_status_includes_cancellation) %}
         {% if broadcast_message.status == 'broadcasting' %}
             <p class="govuk-body govuk-!-margin-bottom-3">
                 Broadcasting stops {{ broadcast_message.finishes_at|format_datetime_human }}.
@@ -84,10 +84,11 @@
                     {
                         "text": "Alert Status",
                     },
+                ] + ([
                     {
                         "text": "Cancellation Status",
                     }
-                ],
+                ] if broadcast_provider_status_rows[0]|length > 2 else []),
                 "rows": broadcast_provider_status_rows
             }) }}
         {% endif %}

--- a/app/templates/views/broadcast/view-message.html
+++ b/app/templates/views/broadcast/view-message.html
@@ -316,7 +316,7 @@
   {% else %}
     {{ page_header(broadcast_message.reference or "Untitled alert") }}
 
-    {{broadcast_details(broadcast_message, current_service, sending_failure)}}
+    {{broadcast_details(broadcast_message, current_service, broadcast_provider_sending_failure)}}
   {% endif %}
 
    {#

--- a/app/templates/views/broadcast/view-message.html
+++ b/app/templates/views/broadcast/view-message.html
@@ -332,7 +332,7 @@
 
   {{alertSummaryList(is_editable, current_service, broadcast_message, areas, broadcast_message.simple_polygons_with_bleed.estimated_area, broadcast_message.count_of_phones, broadcast_message.count_of_phones_likely, is_custom_broadcast)}}
 
-  {{broadcast_message_status_history(broadcast_message, edit_reasons)}}
+  {{broadcast_message_status_history(broadcast_message, edit_reasons, broadcast_provider_status_rows)}}
 
   {#
   can_submit_for_approval determines whether or not the 'Submit for approval' button is displayed for user.

--- a/app/templates/views/broadcast/view-message.html
+++ b/app/templates/views/broadcast/view-message.html
@@ -316,7 +316,7 @@
   {% else %}
     {{ page_header(broadcast_message.reference or "Untitled alert") }}
 
-    {{broadcast_details(broadcast_message, current_service)}}
+    {{broadcast_details(broadcast_message, current_service, sending_failure)}}
   {% endif %}
 
    {#

--- a/app/utils/broadcast.py
+++ b/app/utils/broadcast.py
@@ -375,10 +375,17 @@ def render_current_alert_page(
         errors = [{"text": INVALID_AREA_ERROR_TEXT}]
 
     broadcast_provider_statuses = broadcast_message.get_broadcast_provider_statuses()
-    # We use the static providers here as we always want a row for every MNO - but immediately after hitting broadcast
+    broadcast_provider_contains_cancellation = provider_statuses_contains_cancellation_events(
+        broadcast_provider_statuses
+    )
+    # We loop the static providers here as we always want a row for every MNO - but immediately after hitting broadcast
     # it's unlikely the job(s) to send the alert have even been picked up yet to record a broadcast_event at all.
     broadcast_provider_status_rows = [
-        _get_mno_status_row(mno.name, broadcast_provider_statuses.get(mno.name, {"alert": [], "cancel": []}))
+        _get_mno_status_row(
+            mno.name,
+            broadcast_provider_statuses.get(mno.name, {"alert": [], "cancel": []}),
+            broadcast_provider_contains_cancellation,
+        )
         for mno in BroadcastProvider.PROVIDERS
     ]
 
@@ -410,7 +417,7 @@ def render_current_alert_page(
         edit_reasons=broadcast_message.get_returned_for_edit_reasons(),
         returned_for_edit_by=broadcast_message.get_latest_returned_for_edit_reason().get("created_by_id"),
         broadcast_provider_status_rows=broadcast_provider_status_rows,
-        sending_failure=_provider_statuses_contains_fail_to_send(broadcast_provider_statuses),
+        broadcast_provider_sending_failure=provider_statuses_contains_fail_to_send(broadcast_provider_statuses),
         errors=errors,
         message=broadcast_message,  # Required parameter for map javascripts
     )
@@ -557,13 +564,22 @@ def check_for_missing_fields(broadcast_message):
     return errors
 
 
-def _provider_statuses_contains_fail_to_send(provider_statuses):
+def provider_statuses_contains_fail_to_send(provider_statuses):
     for mno in provider_statuses:
         alert_statuses = provider_statuses[mno].get("alert", [])
         if len(alert_statuses) > 0:
             latest_alert_status = alert_statuses[-1]
             if latest_alert_status["status"] == "returned-error":
                 return True
+
+    return False
+
+
+def provider_statuses_contains_cancellation_events(provider_statuses):
+    for mno in provider_statuses:
+        cancel_statuses = provider_statuses[mno].get("cancel", [])
+        if len(cancel_statuses) > 0:
+            return True
 
     return False
 
@@ -623,23 +639,31 @@ def _get_choose_library_back_link(
             return request.referrer
 
 
-def _get_mno_status_row(mno, mno_statuses):
-    alert_row_text = "No data"
+def _get_mno_status_row(mno, mno_statuses, include_cancellation_status):
+    """
+    Get a row ready to pass to the govukTable macro.
+    MNO | Alert Status | Cancellation Status
+    """
+    alert_row_text = ""
     if len(mno_statuses.get("alert", [])) > 0:
         latest_alert_status = mno_statuses.get("alert", [])[-1]
         alert_row_text = format_provider_status_with_human_time(
             latest_alert_status["status"], latest_alert_status["created_at"]
         )
 
-    cancelled_row_text = "No data"
-    if len(mno_statuses.get("cancel", [])) > 0:
+    cancelled_row_text = ""
+    if include_cancellation_status and len(mno_statuses.get("cancel", [])) > 0:
         latest_cancel_status = mno_statuses.get("cancel", [])[-1]
         cancelled_row_text = format_provider_status_with_human_time(
             latest_cancel_status["status"], latest_cancel_status["created_at"]
         )
 
     mno_capitalised = format_mobile_networks(mno)
-    return [{"text": mno_capitalised}, {"text": alert_row_text}, {"text": cancelled_row_text}]
+    result = [{"text": mno_capitalised}, {"text": alert_row_text}]
+    if include_cancellation_status:
+        result.append({"text": cancelled_row_text})
+
+    return result
 
 
 def get_message_type(message_type):

--- a/app/utils/broadcast.py
+++ b/app/utils/broadcast.py
@@ -8,6 +8,7 @@ from shapely.ops import unary_union
 from app import current_service
 from app.broadcast_areas.models import CustomBroadcastArea, CustomBroadcastAreas
 from app.formatters import (
+    format_mobile_networks,
     format_number_no_scientific,
     format_provider_status_with_human_time,
     round_to_significant_figures,
@@ -623,7 +624,8 @@ def _get_mno_status_row(mno, mno_statuses):
             latest_cancel_status["status"], latest_cancel_status["created_at"]
         )
 
-    return [{"text": mno}, {"text": alert_row_text}, {"text": cancelled_row_text}]
+    mno_capitalised = format_mobile_networks(mno)
+    return [{"text": mno_capitalised}, {"text": alert_row_text}, {"text": cancelled_row_text}]
 
 
 def get_message_type(message_type):

--- a/app/utils/broadcast.py
+++ b/app/utils/broadcast.py
@@ -7,6 +7,7 @@ from shapely.ops import unary_union
 
 from app import current_service
 from app.broadcast_areas.models import CustomBroadcastArea, CustomBroadcastAreas
+from app.config import BroadcastProvider
 from app.formatters import (
     format_mobile_networks,
     format_number_no_scientific,
@@ -374,8 +375,11 @@ def render_current_alert_page(
         errors = [{"text": INVALID_AREA_ERROR_TEXT}]
 
     broadcast_provider_statuses = broadcast_message.get_broadcast_provider_statuses()
+    # We use the static providers here as we always want a row for every MNO - but immediately after hitting broadcast
+    # it's unlikely the job(s) to send the alert have even been picked up yet to record a broadcast_event at all.
     broadcast_provider_status_rows = [
-        _get_mno_status_row(mno, broadcast_provider_statuses[mno]) for mno in broadcast_provider_statuses
+        _get_mno_status_row(mno.name, broadcast_provider_statuses.get(mno.name, {"alert": [], "cancel": []}))
+        for mno in BroadcastProvider.PROVIDERS
     ]
 
     return render_template(
@@ -608,18 +612,16 @@ def _get_choose_library_back_link(
 
 
 def _get_mno_status_row(mno, mno_statuses):
-    # This shouldn't occur as we'll only get MNO statuses for any MNOs with data and a cancel with
-    # an alert should be impossible, but we'll be defensive anyway if data is corrupted.
     alert_row_text = "No data"
-    if len(mno_statuses["alert"]) > 0:
-        latest_alert_status = mno_statuses["alert"][-1]
+    if len(mno_statuses.get("alert", [])) > 0:
+        latest_alert_status = mno_statuses.get("alert", [])[-1]
         alert_row_text = format_provider_status_with_human_time(
             latest_alert_status["status"], latest_alert_status["created_at"]
         )
 
     cancelled_row_text = "No data"
-    if len(mno_statuses["cancel"]) > 0:
-        latest_cancel_status = mno_statuses["cancel"][-1]
+    if len(mno_statuses.get("cancel", [])) > 0:
+        latest_cancel_status = mno_statuses.get("cancel", [])[-1]
         cancelled_row_text = format_provider_status_with_human_time(
             latest_cancel_status["status"], latest_cancel_status["created_at"]
         )

--- a/app/utils/broadcast.py
+++ b/app/utils/broadcast.py
@@ -410,6 +410,7 @@ def render_current_alert_page(
         edit_reasons=broadcast_message.get_returned_for_edit_reasons(),
         returned_for_edit_by=broadcast_message.get_latest_returned_for_edit_reason().get("created_by_id"),
         broadcast_provider_status_rows=broadcast_provider_status_rows,
+        sending_failure=_provider_statuses_contains_fail_to_send(broadcast_provider_statuses),
         errors=errors,
         message=broadcast_message,  # Required parameter for map javascripts
     )
@@ -554,6 +555,17 @@ def check_for_missing_fields(broadcast_message):
         )
         errors.append({"html": f"""<a href="{area_url}">Add alert area</a>"""})
     return errors
+
+
+def _provider_statuses_contains_fail_to_send(provider_statuses):
+    for mno in provider_statuses:
+        alert_statuses = provider_statuses[mno].get("alert", [])
+        if len(alert_statuses) > 0:
+            latest_alert_status = alert_statuses[-1]
+            if latest_alert_status["status"] == "returned-error":
+                return True
+
+    return False
 
 
 def _get_back_link_from_view_broadcast_endpoint():

--- a/app/utils/broadcast.py
+++ b/app/utils/broadcast.py
@@ -374,20 +374,27 @@ def render_current_alert_page(
         # We only validate areas for CustomBroadcastAreas; pre-defined areas are assumed valid
         errors = [{"text": INVALID_AREA_ERROR_TEXT}]
 
-    broadcast_provider_statuses = broadcast_message.get_broadcast_provider_statuses()
-    broadcast_provider_contains_cancellation = provider_statuses_contains_cancellation_events(
-        broadcast_provider_statuses
-    )
-    # We loop the static providers here as we always want a row for every MNO - but immediately after hitting broadcast
-    # it's unlikely the job(s) to send the alert have even been picked up yet to record a broadcast_event at all.
-    broadcast_provider_status_rows = [
-        _get_mno_status_row(
-            mno.name,
-            broadcast_provider_statuses.get(mno.name, {"alert": [], "cancel": []}),
-            broadcast_provider_contains_cancellation,
+    broadcast_provider_status_rows = None
+    broadcast_provider_sending_failure = False
+
+    # Only query for alerts which have been sent
+    if broadcast_message.status in {"broadcasting", "completed", "cancelled"}:
+        broadcast_provider_statuses = broadcast_message.get_broadcast_provider_statuses()
+        broadcast_provider_contains_cancellation = provider_statuses_contains_cancellation_events(
+            broadcast_provider_statuses
         )
-        for mno in BroadcastProvider.PROVIDERS
-    ]
+        # We loop the static providers here as we always want a row for every MNO - but immediately after hitting
+        # broadcast it's unlikely the job(s) to send the alert have even been picked up yet to record a
+        # broadcast_event at all.
+        broadcast_provider_status_rows = [
+            _get_mno_status_row(
+                mno.name,
+                broadcast_provider_statuses.get(mno.name, {"alert": [], "cancel": []}),
+                broadcast_provider_contains_cancellation,
+            )
+            for mno in BroadcastProvider.PROVIDERS
+        ]
+        broadcast_provider_sending_failure = provider_statuses_contains_fail_to_send(broadcast_provider_statuses)
 
     return render_template(
         "views/broadcast/view-message.html",
@@ -417,7 +424,7 @@ def render_current_alert_page(
         edit_reasons=broadcast_message.get_returned_for_edit_reasons(),
         returned_for_edit_by=broadcast_message.get_latest_returned_for_edit_reason().get("created_by_id"),
         broadcast_provider_status_rows=broadcast_provider_status_rows,
-        broadcast_provider_sending_failure=provider_statuses_contains_fail_to_send(broadcast_provider_statuses),
+        broadcast_provider_sending_failure=broadcast_provider_sending_failure,
         errors=errors,
         message=broadcast_message,  # Required parameter for map javascripts
     )

--- a/app/utils/broadcast.py
+++ b/app/utils/broadcast.py
@@ -7,7 +7,11 @@ from shapely.ops import unary_union
 
 from app import current_service
 from app.broadcast_areas.models import CustomBroadcastArea, CustomBroadcastAreas
-from app.formatters import format_number_no_scientific, round_to_significant_figures
+from app.formatters import (
+    format_number_no_scientific,
+    format_provider_status_with_human_time,
+    round_to_significant_figures,
+)
 from app.main.forms import (
     ConfirmBroadcastForm,
     EastingNorthingCoordinatesForm,
@@ -368,6 +372,11 @@ def render_current_alert_page(
         # We only validate areas for CustomBroadcastAreas; pre-defined areas are assumed valid
         errors = [{"text": INVALID_AREA_ERROR_TEXT}]
 
+    broadcast_provider_statuses = broadcast_message.get_broadcast_provider_statuses()
+    broadcast_provider_status_rows = [
+        _get_mno_status_row(mno, broadcast_provider_statuses[mno]) for mno in broadcast_provider_statuses
+    ]
+
     return render_template(
         "views/broadcast/view-message.html",
         broadcast_message=broadcast_message,
@@ -395,6 +404,7 @@ def render_current_alert_page(
         ),
         edit_reasons=broadcast_message.get_returned_for_edit_reasons(),
         returned_for_edit_by=broadcast_message.get_latest_returned_for_edit_reason().get("created_by_id"),
+        broadcast_provider_status_rows=broadcast_provider_status_rows,
         errors=errors,
         message=broadcast_message,  # Required parameter for map javascripts
     )
@@ -594,6 +604,26 @@ def _get_choose_library_back_link(
             )
         else:
             return request.referrer
+
+
+def _get_mno_status_row(mno, mno_statuses):
+    # This shouldn't occur as we'll only get MNO statuses for any MNOs with data and a cancel with
+    # an alert should be impossible, but we'll be defensive anyway if data is corrupted.
+    alert_row_text = "No data"
+    if len(mno_statuses["alert"]) > 0:
+        latest_alert_status = mno_statuses["alert"][-1]
+        alert_row_text = format_provider_status_with_human_time(
+            latest_alert_status["status"], latest_alert_status["created_at"]
+        )
+
+    cancelled_row_text = "No data"
+    if len(mno_statuses["cancel"]) > 0:
+        latest_cancel_status = mno_statuses["cancel"][-1]
+        cancelled_row_text = format_provider_status_with_human_time(
+            latest_cancel_status["status"], latest_cancel_status["created_at"]
+        )
+
+    return [{"text": mno}, {"text": alert_row_text}, {"text": cancelled_row_text}]
 
 
 def get_message_type(message_type):

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -33,7 +33,7 @@ def test_should_show_api_keys_page(
     revoke_link = page.select_one("main tr a.govuk-link.govuk-link--destructive")
 
     assert rows[0] == "API keys Action"
-    assert rows[1] == "another key name Revoked 1 January at 1:00am"
+    assert rows[1] == "another key name Revoked 1 January at 1:00:00am"
     assert rows[2] == "some key name Revoke some key name"
 
     assert normalize_spaces(revoke_link.text) == "Revoke some key name"

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -44,6 +44,19 @@ from tests.utils import xml_path
 
 sample_uuid = sample_uuid()
 
+sending_failure_statuses = {
+    "ee": {
+        "alert": [
+            {"created_at": "2020-02-22T23:23:23.000000", "status": "sending"},
+            {
+                "created_at": "2020-02-22T23:23:23.000000",
+                "status": "returned-error",
+            },
+        ],
+        "cancel": [],
+    }
+}
+
 
 @pytest.mark.parametrize(
     "endpoint, extra_args, expected_get_status, expected_post_status",
@@ -633,12 +646,22 @@ def test_empty_broadcast_dashboard(
         create_active_user_create_broadcasts_permissions(),
     ],
 )
+@pytest.mark.parametrize(
+    "mock_get_broadcast_message_provider_statuses,has_sending_failure",
+    [
+        # For the second lot, pass
+        (None, False),
+        (sending_failure_statuses, True),
+    ],
+    indirect=["mock_get_broadcast_message_provider_statuses"],
+)
 @freeze_time("2020-02-20 02:20")
 def test_broadcast_dashboard(
     client_request,
     service_one,
     mock_get_broadcast_messages,
     mock_get_broadcast_message_provider_statuses,
+    has_sending_failure,
     user,
 ):
     service_one["permissions"] += ["broadcast"]
@@ -650,13 +673,22 @@ def test_broadcast_dashboard(
 
     assert len(page.select(".ajax-block-container")) == len(page.select("h1")) == 1
 
-    assert [normalize_spaces(row.text) for row in page.select(".ajax-block-container")[0].select(".file-list")] == [
-        "Example template This is a test live since today at 2:20am Area: England Scotland",
-        "Half an hour ago This is a test Waiting for approval Area: England Scotland",
-        "Example template This is a test draft",
-        "Hour and a half ago This is a test Waiting for approval Area: England Scotland",
-        "Example template This is a test live since today at 1:20am Area: England Scotland",
-    ]
+    if has_sending_failure:
+        assert [normalize_spaces(row.text) for row in page.select(".ajax-block-container")[0].select(".file-list")] == [
+            "Example template This is a test sending error live since today at 2:20am Area: England Scotland",
+            "Half an hour ago This is a test Waiting for approval Area: England Scotland",
+            "Example template This is a test draft",
+            "Hour and a half ago This is a test Waiting for approval Area: England Scotland",
+            "Example template This is a test sending error live since today at 1:20am Area: England Scotland",
+        ]
+    else:
+        assert [normalize_spaces(row.text) for row in page.select(".ajax-block-container")[0].select(".file-list")] == [
+            "Example template This is a test live since today at 2:20am Area: England Scotland",
+            "Half an hour ago This is a test Waiting for approval Area: England Scotland",
+            "Example template This is a test draft",
+            "Hour and a half ago This is a test Waiting for approval Area: England Scotland",
+            "Example template This is a test live since today at 1:20am Area: England Scotland",
+        ]
 
 
 @pytest.mark.parametrize(
@@ -754,11 +786,22 @@ def test_broadcast_dashboard_json(
         create_active_user_create_broadcasts_permissions(),
     ],
 )
+@pytest.mark.parametrize(
+    "mock_get_broadcast_message_provider_statuses,has_sending_failure",
+    [
+        # For the second lot, pass
+        (None, False),
+        (sending_failure_statuses, True),
+    ],
+    indirect=["mock_get_broadcast_message_provider_statuses"],
+)
 @freeze_time("2020-02-20 02:20")
 def test_previous_broadcasts_page(
     client_request,
     service_one,
     mock_get_broadcast_messages,
+    mock_get_broadcast_message_provider_statuses,
+    has_sending_failure,
     user,
 ):
     service_one["permissions"] += ["broadcast"]
@@ -770,10 +813,16 @@ def test_previous_broadcasts_page(
 
     assert normalize_spaces(page.select_one("main h1").text) == "Past alerts"
     assert len(page.select(".ajax-block-container")) == 1
-    assert [normalize_spaces(row.text) for row in page.select(".ajax-block-container")[0].select(".file-list")] == [
-        "Example template This is a test Yesterday at 2:20pm Area: England Scotland",
-        "Example template This is a test Yesterday at 2:20am Area: England Scotland",
-    ]
+    if has_sending_failure:
+        assert [normalize_spaces(row.text) for row in page.select(".ajax-block-container")[0].select(".file-list")] == [
+            "Example template This is a test sending error Yesterday at 2:20pm Area: England Scotland",
+            "Example template This is a test sending error Yesterday at 2:20am Area: England Scotland",
+        ]
+    else:
+        assert [normalize_spaces(row.text) for row in page.select(".ajax-block-container")[0].select(".file-list")] == [
+            "Example template This is a test Yesterday at 2:20pm Area: England Scotland",
+            "Example template This is a test Yesterday at 2:20am Area: England Scotland",
+        ]
 
 
 @pytest.mark.parametrize(
@@ -788,7 +837,6 @@ def test_rejected_broadcasts_page(
     client_request,
     service_one,
     mock_get_broadcast_messages,
-    mock_get_broadcast_message_provider_statuses,
     user,
 ):
     service_one["permissions"] += ["broadcast"]
@@ -4251,7 +4299,7 @@ def test_start_broadcasting(
 
 
 @pytest.mark.parametrize(
-    "endpoint, created_by_api, extra_fields, expected_paragraphs",
+    "endpoint, created_by_api, extra_fields, mock_get_broadcast_message_provider_statuses, expected_paragraphs",
     (
         (
             ".view_current_broadcast",
@@ -4262,6 +4310,7 @@ def test_start_broadcasting(
                 "created_by": "Alice",
                 "approved_by": "Bob",
             },
+            None,  # No sending failure
             [
                 "live since 20 February at 8:20pm Stop sending",
                 "40,000,000 phones estimated",
@@ -4275,8 +4324,30 @@ def test_start_broadcasting(
         ),
         (
             ".view_current_broadcast",
+            False,
+            {
+                "status": "broadcasting",
+                "finishes_at": "2020-02-23T23:23:23.000000",
+                "created_by": "Alice",
+                "approved_by": "Bob",
+            },
+            sending_failure_statuses,
+            [
+                "sending error live since 20 February at 8:20pm Stop sending",
+                "40,000,000 phones estimated",
+                "Broadcasting stops tomorrow at 11:23:23pm.",
+                "Created by Alice on 20 February at 10:20:20am.",
+                "Submitted by Test User 2 on 20 February at 8:20:20pm.",
+                "Returned by Test User on 20 February at 8:25:20pm.",
+                "Submitted by Test User 2 on 20 February at 9:00:00pm.",
+                "Approved by Bob on 20 February at 9:00:00pm.",
+            ],
+        ),
+        (
+            ".view_current_broadcast",
             True,
             {"status": "broadcasting", "finishes_at": "2020-02-23T23:23:23.000000", "approved_by": "Alice"},
+            None,  # No sending failure
             [
                 "live since 20 February at 8:20pm Stop sending",
                 "40,000,000 phones estimated",
@@ -4297,8 +4368,30 @@ def test_start_broadcasting(
                 "created_by": "Alice",
                 "approved_by": "Bob",
             },
+            None,  # No sending failure
             [
                 "Sent on 20 February at 8:20:20pm.",
+                "40,000,000 phones estimated",
+                "Created by Alice on 20 February at 10:20:20am.",
+                "Submitted by Test User 2 on 20 February at 8:20:20pm.",
+                "Returned by Test User on 20 February at 8:25:20pm.",
+                "Submitted by Test User 2 on 20 February at 9:00:00pm.",
+                "Approved by Bob on 20 February at 9:00:00pm.",
+                "Finished broadcasting today at 10:20:20pm.",
+            ],
+        ),
+        (
+            ".view_previous_broadcast",
+            False,
+            {
+                "status": "broadcasting",
+                "finishes_at": "2020-02-22T22:20:20.000000",  # 2 mins before now()
+                "created_by": "Alice",
+                "approved_by": "Bob",
+            },
+            sending_failure_statuses,
+            [
+                "sending error Sent on 20 February at 8:20:20pm.",
                 "40,000,000 phones estimated",
                 "Created by Alice on 20 February at 10:20:20am.",
                 "Submitted by Test User 2 on 20 February at 8:20:20pm.",
@@ -4316,6 +4409,7 @@ def test_start_broadcasting(
                 "finishes_at": "2020-02-22T22:20:20.000000",  # 2 mins before now()
                 "approved_by": "Alice",
             },
+            None,  # No sending failure
             [
                 "Sent on 20 February at 8:20:20pm.",
                 "40,000,000 phones estimated",
@@ -4336,6 +4430,7 @@ def test_start_broadcasting(
                 "created_by": "Alice",
                 "approved_by": "Bob",
             },
+            None,  # No sending failure
             [
                 "Sent on 20 February at 8:20:20pm.",
                 "40,000,000 phones estimated",
@@ -4358,6 +4453,7 @@ def test_start_broadcasting(
                 "approved_by": "Bob",
                 "cancelled_by": "Carol",
             },
+            None,  # No sending failure
             [
                 "Sent on 20 February at 8:20:20pm.",
                 "40,000,000 phones estimated",
@@ -4379,6 +4475,7 @@ def test_start_broadcasting(
                 "approved_by": "Bob",
                 "cancelled_by_id": None,
             },
+            None,  # No sending failure
             [
                 "Sent on 20 February at 8:20:20pm.",
                 "40,000,000 phones estimated",
@@ -4391,6 +4488,7 @@ def test_start_broadcasting(
             ],
         ),
     ),
+    indirect=["mock_get_broadcast_message_provider_statuses"],
 )
 @freeze_time("2020-02-22T22:22:22.000000")
 def test_view_broadcast_message_page(
@@ -4477,7 +4575,6 @@ def test_view_rejected_broadcast_message_page(
     mock_get_broadcast_message_versions,
     mock_get_broadcast_returned_for_edit_reasons,
     mock_get_latest_edit_reason,
-    mock_get_broadcast_message_provider_statuses,
 ):
     mocker.patch(
         "app.broadcast_message_api_client.get_broadcast_message",
@@ -4614,7 +4711,6 @@ def test_view_pending_broadcast(
     mock_get_broadcast_message_versions,
     mock_get_broadcast_returned_for_edit_reasons,
     mock_get_latest_edit_reason,
-    mock_get_broadcast_message_provider_statuses,
 ):
     broadcast_creator = create_active_user_create_broadcasts_permissions(with_unique_id=True)
     mocker.patch(

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -350,6 +350,7 @@ def test_view_broadcast_page_displays_error_if_area_invalid(
     mock_get_broadcast_message_versions,
     mock_get_broadcast_returned_for_edit_reasons,
     mock_get_latest_edit_reason,
+    mock_get_broadcast_message_provider_statuses,
     mock_update_broadcast_message_status,
 ):
     mocker.patch(
@@ -637,6 +638,7 @@ def test_broadcast_dashboard(
     client_request,
     service_one,
     mock_get_broadcast_messages,
+    mock_get_broadcast_message_provider_statuses,
     user,
 ):
     service_one["permissions"] += ["broadcast"]
@@ -677,6 +679,7 @@ def test_broadcast_dashboard_does_not_have_button_if_user_does_not_have_permissi
     client_request,
     service_one,
     mock_get_broadcast_messages,
+    mock_get_broadcast_message_provider_statuses,
     endpoint,
     user,
 ):
@@ -702,6 +705,7 @@ def test_broadcast_dashboard_has_new_alert_button_if_user_has_permission_to_crea
     client_request,
     service_one,
     mock_get_broadcast_messages,
+    mock_get_broadcast_message_provider_statuses,
     active_user_create_broadcasts_permission,
     endpoint,
 ):
@@ -725,6 +729,7 @@ def test_broadcast_dashboard_json(
     client_request,
     service_one,
     mock_get_broadcast_messages,
+    mock_get_broadcast_message_provider_statuses,
 ):
     service_one["permissions"] += ["broadcast"]
 
@@ -783,6 +788,7 @@ def test_rejected_broadcasts_page(
     client_request,
     service_one,
     mock_get_broadcast_messages,
+    mock_get_broadcast_message_provider_statuses,
     user,
 ):
     service_one["permissions"] += ["broadcast"]
@@ -795,7 +801,7 @@ def test_rejected_broadcasts_page(
     assert normalize_spaces(page.select_one("main h1").text) == "Rejected alerts"
     assert len(page.select(".ajax-block-container")) == 1
     assert [normalize_spaces(row.text) for row in page.select(".ajax-block-container")[0].select(".file-list")] == [
-        "Example template rejected today at 1:20am This is a test",
+        "Example template rejected today at 1:20:00am This is a test",
     ]
 
 
@@ -4259,12 +4265,12 @@ def test_start_broadcasting(
             [
                 "live since 20 February at 8:20pm Stop sending",
                 "40,000,000 phones estimated",
-                "Broadcasting stops tomorrow at 11:23pm.",
-                "Created by Alice on 20 February at 10:20am.",
-                "Submitted by Test User 2 on 20 February at 8:20pm.",
-                "Returned by Test User on 20 February at 8:25pm.",
-                "Submitted by Test User 2 on 20 February at 9:00pm.",
-                "Approved by Bob on 20 February at 9:00pm.",
+                "Broadcasting stops tomorrow at 11:23:23pm.",
+                "Created by Alice on 20 February at 10:20:20am.",
+                "Submitted by Test User 2 on 20 February at 8:20:20pm.",
+                "Returned by Test User on 20 February at 8:25:20pm.",
+                "Submitted by Test User 2 on 20 February at 9:00:00pm.",
+                "Approved by Bob on 20 February at 9:00:00pm.",
             ],
         ),
         (
@@ -4274,12 +4280,12 @@ def test_start_broadcasting(
             [
                 "live since 20 February at 8:20pm Stop sending",
                 "40,000,000 phones estimated",
-                "Broadcasting stops tomorrow at 11:23pm.",
-                "Created from an API call on 20 February at 10:20am.",
-                "Submitted by Test User 2 on 20 February at 8:20pm.",
-                "Returned by Test User on 20 February at 8:25pm.",
-                "Submitted by Test User 2 on 20 February at 9:00pm.",
-                "Approved by Alice on 20 February at 9:00pm.",
+                "Broadcasting stops tomorrow at 11:23:23pm.",
+                "Created from an API call on 20 February at 10:20:20am.",
+                "Submitted by Test User 2 on 20 February at 8:20:20pm.",
+                "Returned by Test User on 20 February at 8:25:20pm.",
+                "Submitted by Test User 2 on 20 February at 9:00:00pm.",
+                "Approved by Alice on 20 February at 9:00:00pm.",
             ],
         ),
         (
@@ -4292,14 +4298,14 @@ def test_start_broadcasting(
                 "approved_by": "Bob",
             },
             [
-                "Sent on 20 February at 8:20pm.",
+                "Sent on 20 February at 8:20:20pm.",
                 "40,000,000 phones estimated",
-                "Created by Alice on 20 February at 10:20am.",
-                "Submitted by Test User 2 on 20 February at 8:20pm.",
-                "Returned by Test User on 20 February at 8:25pm.",
-                "Submitted by Test User 2 on 20 February at 9:00pm.",
-                "Approved by Bob on 20 February at 9:00pm.",
-                "Finished broadcasting today at 10:20pm.",
+                "Created by Alice on 20 February at 10:20:20am.",
+                "Submitted by Test User 2 on 20 February at 8:20:20pm.",
+                "Returned by Test User on 20 February at 8:25:20pm.",
+                "Submitted by Test User 2 on 20 February at 9:00:00pm.",
+                "Approved by Bob on 20 February at 9:00:00pm.",
+                "Finished broadcasting today at 10:20:20pm.",
             ],
         ),
         (
@@ -4311,14 +4317,14 @@ def test_start_broadcasting(
                 "approved_by": "Alice",
             },
             [
-                "Sent on 20 February at 8:20pm.",
+                "Sent on 20 February at 8:20:20pm.",
                 "40,000,000 phones estimated",
-                "Created from an API call on 20 February at 10:20am.",
-                "Submitted by Test User 2 on 20 February at 8:20pm.",
-                "Returned by Test User on 20 February at 8:25pm.",
-                "Submitted by Test User 2 on 20 February at 9:00pm.",
-                "Approved by Alice on 20 February at 9:00pm.",
-                "Finished broadcasting today at 10:20pm.",
+                "Created from an API call on 20 February at 10:20:20am.",
+                "Submitted by Test User 2 on 20 February at 8:20:20pm.",
+                "Returned by Test User on 20 February at 8:25:20pm.",
+                "Submitted by Test User 2 on 20 February at 9:00:00pm.",
+                "Approved by Alice on 20 February at 9:00:00pm.",
+                "Finished broadcasting today at 10:20:20pm.",
             ],
         ),
         (
@@ -4331,14 +4337,14 @@ def test_start_broadcasting(
                 "approved_by": "Bob",
             },
             [
-                "Sent on 20 February at 8:20pm.",
+                "Sent on 20 February at 8:20:20pm.",
                 "40,000,000 phones estimated",
-                "Created by Alice on 20 February at 10:20am.",
-                "Submitted by Test User 2 on 20 February at 8:20pm.",
-                "Returned by Test User on 20 February at 8:25pm.",
-                "Submitted by Test User 2 on 20 February at 9:00pm.",
-                "Approved by Bob on 20 February at 9:00pm.",
-                "Finished broadcasting yesterday at 9:21pm.",
+                "Created by Alice on 20 February at 10:20:20am.",
+                "Submitted by Test User 2 on 20 February at 8:20:20pm.",
+                "Returned by Test User on 20 February at 8:25:20pm.",
+                "Submitted by Test User 2 on 20 February at 9:00:00pm.",
+                "Approved by Bob on 20 February at 9:00:00pm.",
+                "Finished broadcasting yesterday at 9:21:21pm.",
             ],
         ),
         (
@@ -4353,14 +4359,14 @@ def test_start_broadcasting(
                 "cancelled_by": "Carol",
             },
             [
-                "Sent on 20 February at 8:20pm.",
+                "Sent on 20 February at 8:20:20pm.",
                 "40,000,000 phones estimated",
-                "Created by Alice on 20 February at 10:20am.",
-                "Submitted by Test User 2 on 20 February at 8:20pm.",
-                "Returned by Test User on 20 February at 8:25pm.",
-                "Submitted by Test User 2 on 20 February at 9:00pm.",
-                "Approved by Bob on 20 February at 9:00pm.",
-                "Stopped by Carol yesterday at 9:21pm.",
+                "Created by Alice on 20 February at 10:20:20am.",
+                "Submitted by Test User 2 on 20 February at 8:20:20pm.",
+                "Returned by Test User on 20 February at 8:25:20pm.",
+                "Submitted by Test User 2 on 20 February at 9:00:00pm.",
+                "Approved by Bob on 20 February at 9:00:00pm.",
+                "Stopped by Carol yesterday at 9:21:21pm.",
             ],
         ),
         (
@@ -4374,14 +4380,14 @@ def test_start_broadcasting(
                 "cancelled_by_id": None,
             },
             [
-                "Sent on 20 February at 8:20pm.",
+                "Sent on 20 February at 8:20:20pm.",
                 "40,000,000 phones estimated",
-                "Created by Alice on 20 February at 10:20am.",
-                "Submitted by Test User 2 on 20 February at 8:20pm.",
-                "Returned by Test User on 20 February at 8:25pm.",
-                "Submitted by Test User 2 on 20 February at 9:00pm.",
-                "Approved by Bob on 20 February at 9:00pm.",
-                "Stopped by an API call yesterday at 9:21pm.",
+                "Created by Alice on 20 February at 10:20:20am.",
+                "Submitted by Test User 2 on 20 February at 8:20:20pm.",
+                "Returned by Test User on 20 February at 8:25:20pm.",
+                "Submitted by Test User 2 on 20 February at 9:00:00pm.",
+                "Approved by Bob on 20 February at 9:00:00pm.",
+                "Stopped by an API call yesterday at 9:21:21pm.",
             ],
         ),
     ),
@@ -4400,6 +4406,7 @@ def test_view_broadcast_message_page(
     mock_get_broadcast_message_versions,
     mock_get_broadcast_returned_for_edit_reasons,
     mock_get_latest_edit_reason,
+    mock_get_broadcast_message_provider_statuses,
 ):
     mocker.patch(
         "app.broadcast_message_api_client.get_broadcast_message",
@@ -4445,13 +4452,13 @@ def test_view_broadcast_message_page(
                 "submitted_by": "Test User 3",
             },
             [
-                "Rejected yesterday at 9:21pm by Carol.",
+                "Rejected yesterday at 9:21:21pm by Carol.",
                 "40,000,000 phones estimated",
-                "Created by Alice on 20 February at 7:20pm.",
-                "Submitted by Test User 2 on 20 February at 8:20pm.",
-                "Returned by Test User on 20 February at 8:25pm.",
-                "Submitted by Test User 3 on 21 February at 9:21pm.",
-                "Rejected by Carol on 21 February at 9:21pm.",
+                "Created by Alice on 20 February at 7:20:20pm.",
+                "Submitted by Test User 2 on 20 February at 8:20:20pm.",
+                "Returned by Test User on 20 February at 8:25:20pm.",
+                "Submitted by Test User 3 on 21 February at 9:21:21pm.",
+                "Rejected by Carol on 21 February at 9:21:21pm.",
             ],
         ),
     ),
@@ -4470,6 +4477,7 @@ def test_view_rejected_broadcast_message_page(
     mock_get_broadcast_message_versions,
     mock_get_broadcast_returned_for_edit_reasons,
     mock_get_latest_edit_reason,
+    mock_get_broadcast_message_provider_statuses,
 ):
     mocker.patch(
         "app.broadcast_message_api_client.get_broadcast_message",
@@ -4559,6 +4567,7 @@ def test_view_broadcast_message_shows_correct_highlighted_navigation(
     mock_get_broadcast_message_versions,
     mock_get_broadcast_returned_for_edit_reasons,
     mock_get_latest_edit_reason,
+    mock_get_broadcast_message_provider_statuses,
 ):
     mocker.patch(
         "app.broadcast_message_api_client.get_broadcast_message",
@@ -4605,6 +4614,7 @@ def test_view_pending_broadcast(
     mock_get_broadcast_message_versions,
     mock_get_broadcast_returned_for_edit_reasons,
     mock_get_latest_edit_reason,
+    mock_get_broadcast_message_provider_statuses,
 ):
     broadcast_creator = create_active_user_create_broadcasts_permissions(with_unique_id=True)
     mocker.patch(
@@ -4713,6 +4723,7 @@ def test_view_pending_broadcast_without_template(
     mock_get_broadcast_message_versions,
     mock_get_broadcast_returned_for_edit_reasons,
     mock_get_latest_edit_reason,
+    mock_get_broadcast_message_provider_statuses,
 ):
     broadcast_creator = create_active_user_create_broadcasts_permissions(with_unique_id=True)
     mocker.patch(
@@ -4758,6 +4769,7 @@ def test_view_pending_broadcast_from_api_call(
     mock_get_broadcast_message_versions,
     mock_get_broadcast_returned_for_edit_reasons,
     mock_get_latest_edit_reason,
+    mock_get_broadcast_message_provider_statuses,
 ):
     mocker.patch(
         "app.broadcast_message_api_client.get_broadcast_message",
@@ -4820,6 +4832,7 @@ def test_checkbox_to_confirm_non_training_broadcasts(
     mock_get_broadcast_message_versions,
     mock_get_broadcast_returned_for_edit_reasons,
     mock_get_latest_edit_reason,
+    mock_get_broadcast_message_provider_statuses,
 ):
     mocker.patch(
         "app.broadcast_message_api_client.get_broadcast_message",
@@ -4868,6 +4881,7 @@ def test_confirm_approve_non_training_broadcasts_errors_if_not_ticked(
     mock_check_can_update_status,
     mock_get_broadcast_returned_for_edit_reasons,
     mock_get_latest_edit_reason,
+    mock_get_broadcast_message_provider_statuses,
 ):
     page = mocker.patch(
         "app.broadcast_message_api_client.get_broadcast_message",
@@ -4912,6 +4926,7 @@ def test_can_approve_own_broadcast_in_training_mode(
     mock_get_broadcast_message_versions,
     mock_get_broadcast_returned_for_edit_reasons,
     mock_get_latest_edit_reason,
+    mock_get_broadcast_message_provider_statuses,
 ):
     mocker.patch(
         "app.broadcast_message_api_client.get_broadcast_message",
@@ -4973,6 +4988,7 @@ def test_can_approve_own_broadcast_if_service_is_live_and_user_didnt_submit_aler
     mock_get_broadcast_message_versions,
     mock_get_broadcast_returned_for_edit_reasons,
     mock_get_latest_edit_reason,
+    mock_get_broadcast_message_provider_statuses,
 ):
     service_one["restricted"] = False
     mocker.patch(
@@ -5024,6 +5040,7 @@ def test_cannot_approve_own_broadcast_if_service_is_live_and_user_submitted_aler
     mock_get_broadcast_message_versions,
     mock_get_broadcast_returned_for_edit_reasons,
     mock_get_latest_edit_reason,
+    mock_get_broadcast_message_provider_statuses,
 ):
     service_one["restricted"] = False
     mocker.patch(
@@ -5079,6 +5096,7 @@ def test_view_only_user_cant_approve_broadcast_created_by_someone_else(
     mock_get_broadcast_message_versions,
     mock_get_broadcast_returned_for_edit_reasons,
     mock_get_latest_edit_reason,
+    mock_get_broadcast_message_provider_statuses,
 ):
     mocker.patch(
         "app.broadcast_message_api_client.get_broadcast_message",
@@ -5120,6 +5138,7 @@ def test_view_only_user_cant_approve_broadcasts_they_created(
     mock_get_broadcast_message_versions,
     mock_get_broadcast_returned_for_edit_reasons,
     mock_get_latest_edit_reason,
+    mock_get_broadcast_message_provider_statuses,
 ):
     mocker.patch(
         "app.broadcast_message_api_client.get_broadcast_message",
@@ -5186,6 +5205,7 @@ def test_user_without_approve_permission_cant_approve_broadcast_created_by_someo
     mock_get_broadcast_message_versions,
     mock_get_broadcast_returned_for_edit_reasons,
     mock_get_latest_edit_reason,
+    mock_get_broadcast_message_provider_statuses,
 ):
     current_user = create_active_user_create_broadcasts_permissions(with_unique_id=True)
     mocker.patch(
@@ -5232,6 +5252,7 @@ def test_user_without_approve_permission_cant_approve_broadcast_they_created(
     mock_get_broadcast_message_versions,
     mock_get_broadcast_returned_for_edit_reasons,
     mock_get_latest_edit_reason,
+    mock_get_broadcast_message_provider_statuses,
 ):
     mocker.patch(
         "app.broadcast_message_api_client.get_broadcast_message",
@@ -5495,6 +5516,7 @@ def test_reject_broadcast_displays_error_when_no_reason_provided(
     mock_check_can_update_status,
     mock_get_broadcast_returned_for_edit_reasons,
     mock_get_latest_edit_reason,
+    mock_get_broadcast_message_provider_statuses,
 ):
     mocker.patch(
         "app.broadcast_message_api_client.get_broadcast_message",
@@ -5545,6 +5567,7 @@ def test_return_broadcast_for_edit_displays_error_when_no_reason_provided(
     mock_check_can_update_status,
     mock_get_broadcast_returned_for_edit_reasons,
     mock_get_latest_edit_reason,
+    mock_get_broadcast_message_provider_statuses,
 ):
     mocker.patch(
         "app.broadcast_message_api_client.get_broadcast_message",
@@ -5594,6 +5617,7 @@ def test_can_return_broadcast_for_edit(
     mock_check_can_update_status,
     mock_get_broadcast_returned_for_edit_reasons,
     mock_get_latest_edit_reason,
+    mock_get_broadcast_message_provider_statuses,
 ):
     mocker.patch(
         "app.broadcast_message_api_client.get_broadcast_message",
@@ -5637,6 +5661,7 @@ def test_discard_broadcast(
     mock_get_broadcast_message_versions,
     mock_get_broadcast_returned_for_edit_reasons,
     mock_get_latest_edit_reason,
+    mock_get_broadcast_message_provider_statuses,
 ):
     mocker.patch(
         "app.broadcast_message_api_client.get_broadcast_message",
@@ -5685,6 +5710,7 @@ def test_cannot_reject_broadcast_if_transition_not_allowed(
     mock_check_can_update_status_returns_http_error,
     mock_get_broadcast_returned_for_edit_reasons,
     mock_get_latest_edit_reason,
+    mock_get_broadcast_message_provider_statuses,
 ):
     mocker.patch(
         "app.broadcast_message_api_client.get_broadcast_message",
@@ -5733,6 +5759,7 @@ def test_cannot_discard_broadcast_if_transition_not_allowed(
     mock_check_can_update_status_returns_http_error,
     mock_get_broadcast_returned_for_edit_reasons,
     mock_get_latest_edit_reason,
+    mock_get_broadcast_message_provider_statuses,
 ):
     mocker.patch(
         "app.broadcast_message_api_client.get_broadcast_message",
@@ -5925,6 +5952,7 @@ def test_cannot_submit_if_transition_not_allowed(
     mock_check_can_update_status_returns_http_error,
     mock_get_broadcast_returned_for_edit_reasons,
     mock_get_latest_edit_reason,
+    mock_get_broadcast_message_provider_statuses,
 ):
     mocker.patch(
         "app.broadcast_message_api_client.get_broadcast_message",
@@ -6011,6 +6039,7 @@ def test_can_view_current_page_for_draft(
     mock_get_broadcast_message_versions,
     mock_get_broadcast_returned_for_edit_reasons,
     mock_get_latest_edit_reason,
+    mock_get_broadcast_message_provider_statuses,
 ):
     service_one["permissions"] += ["broadcast"]
     client_request.get(
@@ -6064,6 +6093,7 @@ def test_cancel_broadcast(
     mock_check_can_update_status,
     mock_get_broadcast_returned_for_edit_reasons,
     mock_get_latest_edit_reason,
+    mock_get_broadcast_message_provider_statuses,
 ):
     """
     users with 'create/approve_broadcasts' permissions and platform admins should be able to cancel broadcasts.
@@ -6114,6 +6144,7 @@ def test_cannot_cancel_broadcast_if_transition_not_allowed(
     mock_check_can_update_status_returns_http_error,
     mock_get_broadcast_returned_for_edit_reasons,
     mock_get_latest_edit_reason,
+    mock_get_broadcast_message_provider_statuses,
 ):
     service_one["permissions"] += ["broadcast"]
 
@@ -6771,6 +6802,7 @@ def test_view_draft_broadcast_message_page(
     mock_get_broadcast_message_versions,
     mock_get_broadcast_returned_for_edit_reasons,
     mock_get_latest_edit_reason,
+    mock_get_broadcast_message_provider_statuses,
 ):
     mocker.patch(
         "app.broadcast_message_api_client.get_broadcast_message",

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -44,6 +44,38 @@ from tests.utils import xml_path
 
 sample_uuid = sample_uuid()
 
+sending_success_statuses = {
+    "ee": {
+        "alert": [
+            {"created_at": "2020-02-22T23:23:23.000000", "status": "sending"},
+            {
+                "created_at": "2020-02-22T23:23:23.000000",
+                "status": "returned-ack",
+            },
+        ],
+        "cancel": [],
+    }
+}
+
+sending_success_cancelled_statuses = {
+    "ee": {
+        "alert": [
+            {"created_at": "2020-02-22T23:23:23.000000", "status": "sending"},
+            {
+                "created_at": "2020-02-22T23:23:23.000000",
+                "status": "returned-ack",
+            },
+        ],
+        "cancel": [
+            {"created_at": "2020-02-22T23:24:24.000000", "status": "sending"},
+            {
+                "created_at": "2020-02-22T23:24:24.000000",
+                "status": "returned-ack",
+            },
+        ],
+    }
+}
+
 sending_failure_statuses = {
     "ee": {
         "alert": [
@@ -4299,7 +4331,8 @@ def test_start_broadcasting(
 
 
 @pytest.mark.parametrize(
-    "endpoint, created_by_api, extra_fields, mock_get_broadcast_message_provider_statuses, expected_paragraphs",
+    "endpoint, created_by_api, extra_fields, mock_get_broadcast_message_provider_statuses, "
+    + "operator_statuses_text, expected_paragraphs",
     (
         (
             ".view_current_broadcast",
@@ -4310,7 +4343,8 @@ def test_start_broadcasting(
                 "created_by": "Alice",
                 "approved_by": "Bob",
             },
-            None,  # No sending failure
+            sending_success_statuses,
+            "Operator Statuses Operator Alert Status EE Sent today at 11:23:23pm O2 Three Vodafone",
             [
                 "live since 20 February at 8:20pm Stop sending",
                 "40,000,000 phones estimated",
@@ -4332,6 +4366,7 @@ def test_start_broadcasting(
                 "approved_by": "Bob",
             },
             sending_failure_statuses,
+            "Operator Statuses Operator Alert Status EE Failed today at 11:23:23pm O2 Three Vodafone",
             [
                 "sending error live since 20 February at 8:20pm Stop sending",
                 "40,000,000 phones estimated",
@@ -4347,7 +4382,8 @@ def test_start_broadcasting(
             ".view_current_broadcast",
             True,
             {"status": "broadcasting", "finishes_at": "2020-02-23T23:23:23.000000", "approved_by": "Alice"},
-            None,  # No sending failure
+            sending_success_statuses,
+            "Operator Statuses Operator Alert Status EE Sent today at 11:23:23pm O2 Three Vodafone",
             [
                 "live since 20 February at 8:20pm Stop sending",
                 "40,000,000 phones estimated",
@@ -4368,7 +4404,8 @@ def test_start_broadcasting(
                 "created_by": "Alice",
                 "approved_by": "Bob",
             },
-            None,  # No sending failure
+            sending_success_statuses,
+            "Operator Statuses Operator Alert Status EE Sent today at 11:23:23pm O2 Three Vodafone",
             [
                 "Sent on 20 February at 8:20:20pm.",
                 "40,000,000 phones estimated",
@@ -4390,6 +4427,7 @@ def test_start_broadcasting(
                 "approved_by": "Bob",
             },
             sending_failure_statuses,
+            "Operator Statuses Operator Alert Status EE Failed today at 11:23:23pm O2 Three Vodafone",
             [
                 "sending error Sent on 20 February at 8:20:20pm.",
                 "40,000,000 phones estimated",
@@ -4409,7 +4447,8 @@ def test_start_broadcasting(
                 "finishes_at": "2020-02-22T22:20:20.000000",  # 2 mins before now()
                 "approved_by": "Alice",
             },
-            None,  # No sending failure
+            sending_success_statuses,
+            "Operator Statuses Operator Alert Status EE Sent today at 11:23:23pm O2 Three Vodafone",
             [
                 "Sent on 20 February at 8:20:20pm.",
                 "40,000,000 phones estimated",
@@ -4430,7 +4469,8 @@ def test_start_broadcasting(
                 "created_by": "Alice",
                 "approved_by": "Bob",
             },
-            None,  # No sending failure
+            sending_success_statuses,
+            "Operator Statuses Operator Alert Status EE Sent today at 11:23:23pm O2 Three Vodafone",
             [
                 "Sent on 20 February at 8:20:20pm.",
                 "40,000,000 phones estimated",
@@ -4453,7 +4493,9 @@ def test_start_broadcasting(
                 "approved_by": "Bob",
                 "cancelled_by": "Carol",
             },
-            None,  # No sending failure
+            sending_success_cancelled_statuses,
+            "Operator Statuses Operator Alert Status Cancellation Status EE Sent today at 11:23:23pm "
+            + "Sent today at 11:24:24pm O2 Three Vodafone",
             [
                 "Sent on 20 February at 8:20:20pm.",
                 "40,000,000 phones estimated",
@@ -4475,7 +4517,9 @@ def test_start_broadcasting(
                 "approved_by": "Bob",
                 "cancelled_by_id": None,
             },
-            None,  # No sending failure
+            sending_success_cancelled_statuses,
+            "Operator Statuses Operator Alert Status Cancellation Status EE Sent today at 11:23:23pm "
+            + "Sent today at 11:24:24pm O2 Three Vodafone",
             [
                 "Sent on 20 February at 8:20:20pm.",
                 "40,000,000 phones estimated",
@@ -4505,6 +4549,7 @@ def test_view_broadcast_message_page(
     mock_get_broadcast_returned_for_edit_reasons,
     mock_get_latest_edit_reason,
     mock_get_broadcast_message_provider_statuses,
+    operator_statuses_text,
 ):
     mocker.patch(
         "app.broadcast_message_api_client.get_broadcast_message",
@@ -4533,6 +4578,8 @@ def test_view_broadcast_message_page(
     )
 
     assert [normalize_spaces(p.text) for p in page.select("main p.govuk-body")] == expected_paragraphs
+
+    assert normalize_spaces(page.select("table")[0].text) == operator_statuses_text
 
 
 @pytest.mark.parametrize(
@@ -4610,6 +4657,7 @@ def test_view_rejected_broadcast_message_page(
     )
 
     assert [normalize_spaces(p.text) for p in page.select("main p.govuk-body")] == expected_paragraphs
+    assert not page.select("table")  # No operator statuses table
 
 
 @pytest.mark.parametrize(
@@ -4756,6 +4804,7 @@ def test_view_pending_broadcast(
         "Reject alert"
     )
     assert not page.select(".banner input[type=checkbox]")
+    assert not page.select("table")  # No operator statuses table
 
     approval_form = page.select_one("form#approve")
     assert approval_form["method"] == "post"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2466,6 +2466,14 @@ def mock_get_latest_edit_reason(mocker):
 
 
 @pytest.fixture(scope="function")
+def mock_get_broadcast_message_provider_statuses(mocker):
+    return mocker.patch(
+        "app.broadcast_message_api_client.get_broadcast_provider_statuses",
+        return_value={"ee": {"alert": [], "cancel": []}},
+    )
+
+
+@pytest.fixture(scope="function")
 def mock_update_broadcast_message(
     mocker,
     fake_uuid,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2466,10 +2466,13 @@ def mock_get_latest_edit_reason(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_get_broadcast_message_provider_statuses(mocker):
+def mock_get_broadcast_message_provider_statuses(mocker, request):
+    return_value = getattr(request, "param", None)
+
     return mocker.patch(
         "app.broadcast_message_api_client.get_broadcast_provider_statuses",
-        return_value={"ee": {"alert": [], "cancel": []}},
+        # Default to no real statuses (no failure)
+        return_value=return_value or {"ee": {"alert": [], "cancel": []}},
     )
 
 


### PR DESCRIPTION
> Requires https://github.com/alphagov/emergency-alerts-api/pull/336 for the new endpoint

This adds two new elements to the UI:
- In the alert listing and alert itself we now have a tag/badge to highlight if there's one or more MNOs with a 'returned-error' status when sending. This also appears on the past alerts page.
  - <img width="695" height="474" alt="image" src="https://github.com/user-attachments/assets/eea6e1ca-4ae7-4e4b-93e2-c5d46b2d902c" />
  - <img width="887" height="400" alt="image" src="https://github.com/user-attachments/assets/5bfe6d8b-20f1-4c3c-b5ed-f0e0e51c6952" />
  - <img width="894" height="617" alt="image" src="https://github.com/user-attachments/assets/6cd9ca63-c4ba-4525-a010-1e7807213bff" />

- At the bottom of the alert page is a table breaking down the _latest_ status per MNO. If there's a cancellation (not a natural expiry) then the table will also have a column for the cancellation sending event too. This table should only appear for alerts which have been sent.
  - As requested, we now show the seconds in audit events. This is more so the delay between approving and it being sent can easily be observed.
  - It should be noted that immediately after hitting 'broadcast' the table will contain no data. This is because the job to send the alert won't have been picked up yet. There is a 'sending' status that can be displayed, but in this scenario the job hasn't even started to create that.
    <img width="728" height="332" alt="image" src="https://github.com/user-attachments/assets/18029537-89ce-490e-9c23-63e3f72fa276" />
  - <img width="792" height="495" alt="image" src="https://github.com/user-attachments/assets/7254cf9f-fc7c-446a-95fb-dade76145f26" />
  - <img width="700" height="344" alt="image" src="https://github.com/user-attachments/assets/80fb972f-b3a7-4b33-90f4-6d2a89517bad" />
