### PR TITLE
EAS-2983: Don't allow newlines in `next` query parameter for redirects

### DIFF
--- a/app/utils/login.py
+++ b/app/utils/login.py
@@ -1,3 +1,4 @@
+import re
 from datetime import datetime, timezone
 from functools import wraps
 
@@ -54,13 +55,21 @@ def email_needs_revalidating(user):
     return not is_less_than_days_ago(user.email_access_validated_at, 90)
 
 
+# Werkzeug denies newlines in headers, but otherwise does no other filtering - so match that logic
+newline_regex = re.compile(r"[\r\n]")
+
+
 # see https://stackoverflow.com/questions/60532973/how-do-i-get-a-is-safe-url-function-to-use-with-flask-and-how-does-it-work  # noqa
 def is_safe_redirect_url(target):
     from urllib.parse import urljoin, urlparse
 
     host_url = urlparse(request.host_url)
     redirect_url = urlparse(urljoin(request.host_url, target))
-    return redirect_url.scheme in ("http", "https") and host_url.netloc == redirect_url.netloc
+    return (
+        redirect_url.scheme in ("http", "https")
+        and host_url.netloc == redirect_url.netloc
+        and newline_regex.search(target) is None
+    )
 
 
 def is_less_than_days_ago(date_from_db, number_of_days):

--- a/tests/app/utils/test_login.py
+++ b/tests/app/utils/test_login.py
@@ -1,8 +1,13 @@
 import pytest
+from flask import url_for
 from freezegun import freeze_time
 
 from app.models.user import User
-from app.utils.login import email_needs_revalidating, is_less_than_days_ago
+from app.utils.login import (
+    email_needs_revalidating,
+    is_less_than_days_ago,
+    redirect_when_logged_in,
+)
 
 
 @freeze_time("2020-11-27T12:00:00")
@@ -33,3 +38,22 @@ def test_email_needs_revalidating(
 @freeze_time("2020-02-14T12:00:00")
 def test_is_less_than_days_ago(date_from_db, expected_result):
     assert is_less_than_days_ago(date_from_db, 90) == expected_result
+
+
+@pytest.mark.parametrize(
+    "next, allow_redirect",
+    [
+        ("foo", True),
+        ("foo/bar", True),
+        ("https://localhost/next", True),
+        ("https://request-elsewhere/next", False),
+        ("foo/bar\n", False),
+        ("foo/bar\ncontent", False),
+    ],
+)
+def test_redirect_when_logged_in(notify_admin, next, allow_redirect):
+    with notify_admin.test_request_context(query_string={"next": next}):
+        fallback_redirect_url = url_for("main.show_accounts_or_dashboard")
+
+        response = redirect_when_logged_in(False)
+        assert response.headers["Location"] == next if allow_redirect else fallback_redirect_url


### PR DESCRIPTION
In the past we've had a couple of 500s appear from `next` containing a newline, which Werkzeug doesn't allow and throws. Instead we should handle that more gracefully, and treat it as an invalid redirect and silently ignore it.