### PR TITLE
EAS-3050: Adds new default duration for Operator services & adjusts Training services duration maximum

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -101,7 +101,7 @@ class Config(object):
 
     DEFAULT_DURATION_PERIODS = {
         "live": 81000,
-        "training": 14400,
+        "training": 81000,
         "operator": 900,
     }  # Default alert durations for live, training or operator
 

--- a/app/config.py
+++ b/app/config.py
@@ -102,7 +102,8 @@ class Config(object):
     DEFAULT_DURATION_PERIODS = {
         "live": 81000,
         "training": 14400,
-    }  # Default alert duration for live services or training (i.e. test or operator services)
+        "operator": 900,
+    }  # Default alert durations for live, training or operator
 
 
 class Hosted(Config):

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1209,14 +1209,14 @@ class ChooseDurationForm(StripWhitespaceForm):
             self.minutes.errors.append("Duration must be at least 5 minutes")
             return False
 
-        if channel in ["test", "operator"]:
+        if channel in ["operator"]:
             if duration > timedelta(hours=4):
                 if hours > 4:
                     self.hours.errors.append("Duration must not be greater than 4 hours")
                 if hours == 4:
                     self.minutes.errors.append("Duration must not be greater than 4 hours")
                 return False
-        elif channel in ["government", "severe"]:
+        elif channel in ["government", "severe", "test"]:
             if duration > timedelta(hours=22, minutes=30):
                 if hours > 22:
                     self.hours.errors.append("Maximum duration is 22 hours, 30 minutes")

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1164,8 +1164,10 @@ class ChooseDurationForm(StripWhitespaceForm):
         self.channel = channel
         if duration is None:
             if self.hours.data is None and self.minutes.data is None:
-                if channel in ["test", "operator"]:
+                if channel == "test":
                     hours, minutes = parse_seconds_as_hours_and_minutes(Config.DEFAULT_DURATION_PERIODS.get("training"))
+                elif channel == "operator":
+                    hours, minutes = parse_seconds_as_hours_and_minutes(Config.DEFAULT_DURATION_PERIODS.get("operator"))
                 else:
                     hours, minutes = parse_seconds_as_hours_and_minutes(Config.DEFAULT_DURATION_PERIODS.get("live"))
                 self.hours.data = hours

--- a/app/models/broadcast_message.py
+++ b/app/models/broadcast_message.py
@@ -240,7 +240,7 @@ class BroadcastMessage(BaseBroadcast):
 
     def approve_broadcast(self, channel):
         if self.duration == 0 or self.duration is None:
-            if channel in {"test", "operator"}:
+            if channel in {"operator"}:
                 ttl = timedelta(hours=4, minutes=0)
             else:
                 ttl = timedelta(hours=22, minutes=30)

--- a/app/templates/components/alert-summary-list.html
+++ b/app/templates/components/alert-summary-list.html
@@ -57,9 +57,13 @@
                 {{ broadcast_message.duration|format_seconds_duration_as_time }}
             </p>
         {% else %}
-            {% if  current_service.broadcast_channel in ["test", "operator"] %}
+            {% if  current_service.broadcast_channel == "test" %}
                 <p class="govuk-!-margin-right-2 duration-preview">
                     {{ config.get('DEFAULT_DURATION_PERIODS')["training"]|format_seconds_duration_as_time }}
+                </p>
+            {% elif current_service.broadcast_channel == "operator" %}
+                <p class="govuk-!-margin-right-2 duration-preview">
+                    {{ config.get('DEFAULT_DURATION_PERIODS')["operator"]|format_seconds_duration_as_time }}
                 </p>
             {% else %}
                 <p class="govuk-!-margin-right-2 duration-preview">

--- a/app/templates/views/broadcast/duration.html
+++ b/app/templates/views/broadcast/duration.html
@@ -36,7 +36,7 @@
     <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-3">
       <p class="govuk-body govuk-!-margin-bottom-3">
         Maximum permitted duration is
-        {% if form.channel in ['test', 'operator'] %}
+        {% if form.channel in ['operator'] %}
           4 hours.
         {% else %}
           22 hours, 30 minutes.

--- a/tests/app/main/forms/test_choose_duration.py
+++ b/tests/app/main/forms/test_choose_duration.py
@@ -3,6 +3,7 @@ from werkzeug.datastructures import MultiDict
 
 from app.main.forms import ChooseDurationForm
 
+
 @pytest.mark.parametrize(
     "channel, hours, minutes",
     (
@@ -14,8 +15,7 @@ from app.main.forms import ChooseDurationForm
 def test_choose_duration_has_default(channel, hours, minutes):
     # Form initialised with no data so uses defaults
     form = ChooseDurationForm(channel, duration=None, formdata={})
-    assert form.data == {'hours': hours, 'minutes': minutes}
-
+    assert form.data == {"hours": hours, "minutes": minutes}
 
 
 @pytest.mark.parametrize(

--- a/tests/app/main/forms/test_choose_duration.py
+++ b/tests/app/main/forms/test_choose_duration.py
@@ -3,6 +3,20 @@ from werkzeug.datastructures import MultiDict
 
 from app.main.forms import ChooseDurationForm
 
+@pytest.mark.parametrize(
+    "channel, hours, minutes",
+    (
+        ("severe", 22, 30),
+        ("test", 22, 30),
+        ("operator", 0, 15),
+    ),
+)
+def test_choose_duration_has_default(channel, hours, minutes):
+    # Form initialised with no data so uses defaults
+    form = ChooseDurationForm(channel, duration=None, formdata={})
+    assert form.data == {'hours': hours, 'minutes': minutes}
+
+
 
 @pytest.mark.parametrize(
     "channel, hours, minutes",
@@ -40,7 +54,9 @@ def test_choose_duration_no_duration_displays_error(channel):
     "channel, hours, minutes, expected_hours_error, expected_minutes_error",
     (
         ("severe", 22, 31, [], ["Maximum duration is 22 hours, 30 minutes"]),
-        ("test", 5, 0, ["Duration must not be greater than 4 hours"], []),
+        ("severe", 23, 29, ["Maximum duration is 22 hours, 30 minutes"], []),
+        ("test", 22, 32, [], ["Maximum duration is 22 hours, 30 minutes"]),
+        ("test", 23, 29, ["Maximum duration is 22 hours, 30 minutes"], []),
         ("operator", 4, 1, [], ["Duration must not be greater than 4 hours"]),
     ),
 )


### PR DESCRIPTION
This PR adds a new default for Operator service alert duration, set to 15 mins.