### PR TITLE
EAS-3062: Adds special character guidance as hint text

### DIFF
--- a/app/templates/views/broadcast/write-new-broadcast.html
+++ b/app/templates/views/broadcast/write-new-broadcast.html
@@ -91,7 +91,8 @@
           autosize=True,
           width='1-1',
           rows=5,
-          extra_form_group_classes='govuk-!-margin-bottom-2'
+          extra_form_group_classes='govuk-!-margin-bottom-2',
+          hint="If you add special characters to the alert message (for example letters with diacritics), the character limit will be reduced to 615."
         ) }}
       </div>
       <div class="govuk-grid-column-full">

--- a/app/templates/views/edit-broadcast-template.html
+++ b/app/templates/views/edit-broadcast-template.html
@@ -44,7 +44,8 @@
           autosize=True,
           width='1-1',
           rows=5,
-          extra_form_group_classes='govuk-!-margin-bottom-2'
+          extra_form_group_classes='govuk-!-margin-bottom-2',
+          hint="If you add special characters to the alert message (for example letters with diacritics), the character limit will be reduced to 615."
         ) }}
       </div>
       <div class="govuk-grid-column-full">

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -880,7 +880,10 @@ def test_write_new_broadcast_page(
     assert normalize_spaces(page.select_one("label[for=reference]").text) == "Reference"
     assert page.select_one("input[type=text]")["name"] == "reference"
 
-    assert normalize_spaces(page.select_one("label[for=content]").text) == "Alert message"
+    assert normalize_spaces(page.select_one("label[for=content]").text) == (
+        "Alert message If you add special characters to the alert message "
+        "(for example letters with diacritics), the character limit will be reduced to 615."
+    )
     assert page.select_one("textarea")["name"] == "content"
     assert page.select_one("textarea")["data-notify-module"] == "enhanced-textbox"
     assert page.select_one("textarea")["data-highlight-placeholders"] == "false"
@@ -6229,7 +6232,10 @@ def test_edit_broadcast_page(
     assert normalize_spaces(page.select_one("label[for=reference]").text) == "Reference"
     assert page.select_one("input[type=text]")["name"] == "reference"
 
-    assert normalize_spaces(page.select_one("label[for=content]").text) == "Alert message"
+    assert normalize_spaces(page.select_one("label[for=content]").text) == (
+        "Alert message If you add special characters to the alert message "
+        "(for example letters with diacritics), the character limit will be reduced to 615."
+    )
     assert normalize_spaces(page.select_one("textarea").text) == "This is a test for edit_broadcast"
     assert page.select_one("textarea")["name"] == "content"
     assert page.select_one("textarea")["data-notify-module"] == "enhanced-textbox"

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1215,7 +1215,10 @@ def test_edit_content_redirects_to_write_template_page_and_updates_template(
 
     assert [normalize_spaces(p.text) for p in page.select("label")] == [
         "Reference",
-        "Alert message",
+        (
+            "Alert message If you add special characters to the alert message "
+            "(for example letters with diacritics), the character limit will be reduced to 615."
+        ),
     ]
     assert normalize_spaces(page.select_one(".govuk-input")["value"]) == "Sample Template"
     assert normalize_spaces(page.select_one("textarea").text) == "Template <em>content</em> with & entity"


### PR DESCRIPTION
This PR adds guidance to Alert message field hint text, to make users aware of the reduced character limit when including special characters in alert message.