### PR TITLE
Fix/Remove references to deprecated `manage_settings` permission

### DIFF
--- a/app/main/views/find_users.py
+++ b/app/main/views/find_users.py
@@ -41,11 +41,8 @@ def archive_user(user_id):
         try:
             user_api_client.archive_user(user_id)
         except HTTPError as e:
-            if e.status_code == 400 and "manage_settings" in e.message:
-                flash(
-                    "User can’t be removed from a service - "
-                    "check all services have another team member with manage_settings"
-                )
+            if e.status_code == 400:
+                flash("User can’t be archived - check all services the user belongs to have other active team members")
                 return redirect(url_for("main.user_information", user_id=user_id))
 
         create_archive_user_event(

--- a/app/utils/user_permissions.py
+++ b/app/utils/user_permissions.py
@@ -2,7 +2,7 @@ from itertools import chain
 
 permission_mappings = {
     "manage_templates": ["manage_templates"],
-    "manage_service": ["manage_users", "manage_settings"],
+    "manage_service": ["manage_users"],
     "manage_api_keys": ["manage_api_keys"],
     "view_activity": ["view_activity"],
     "create_broadcasts": ["create_broadcasts", "reject_broadcasts", "cancel_broadcasts"],

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -95,7 +95,6 @@ def user_json(
                 "view_activity",
                 "manage_users",
                 "manage_templates",
-                "manage_settings",
                 "manage_api_keys",
             ]
         }

--- a/tests/app/main/test_permissions.py
+++ b/tests/app/main/test_permissions.py
@@ -61,7 +61,7 @@ def test_services_pages_that_org_users_are_allowed_to_see(
 ):
     api_user_active["services"] = user_services
     api_user_active["organisations"] = user_organisations
-    api_user_active["permissions"] = {service_id: ["manage_users", "manage_settings"] for service_id in user_services}
+    api_user_active["permissions"] = {service_id: ["manage_users"] for service_id in user_services}
     service = service_json(
         name="SERVICE WITH ORG",
         id_=SERVICE_ONE_ID,

--- a/tests/app/main/views/test_find_users.py
+++ b/tests/app/main/views/test_find_users.py
@@ -2,6 +2,7 @@ import uuid
 
 import pytest
 from flask import url_for
+from notifications_python_client.errors import HTTPError
 
 from tests import user_json
 from tests.conftest import normalize_spaces
@@ -238,6 +239,42 @@ def test_archive_user_posts_to_user_client(
     mock_user_client.assert_called_once_with("/user/{}/archive".format(api_user_active["id"]), data=None)
 
     assert mock_events.called
+
+
+def test_archive_user_shows_error_message_if_user_cannot_be_archived(
+    client_request,
+    platform_admin_user,
+    api_user_active,
+    mocker,
+    mock_get_non_empty_organisations_and_services_for_user,
+):
+    mocker.patch(
+        "app.user_api_client.post",
+        side_effect=HTTPError(
+            response=mocker.Mock(
+                status_code=400,
+                json={
+                    "result": "error",
+                    "message": "User can’t be archived - check all services"
+                    " the user belongs to have other active team members",
+                },
+            ),
+            message="User can’t be archived - check all services the user belongs to have other active team members",
+        ),
+    )
+
+    client_request.login(platform_admin_user)
+    page = client_request.post(
+        "main.archive_user",
+        user_id=api_user_active["id"],
+        _follow_redirects=True,
+    )
+
+    assert normalize_spaces(page.select_one("h1").text) == "Platform admin user"
+    assert (
+        normalize_spaces(page.select_one(".banner-dangerous").text)
+        == "User can’t be archived - check all services the user belongs to have other active team members"
+    )
 
 
 def test_archive_user_does_not_create_event_if_user_client_raises_unexpected_exception(

--- a/tests/app/main/views/test_find_users.py
+++ b/tests/app/main/views/test_find_users.py
@@ -255,12 +255,10 @@ def test_archive_user_shows_error_message_if_user_cannot_be_archived(
                 status_code=400,
                 json={
                     "result": "error",
-                    "message": "User can’t be removed from a service - check all services have another "
-                    "team member with manage_settings",
+                    "message": "User can’t be archived - check all services the user belongs to have other active team members",
                 },
             ),
-            message="User can’t be removed from a service - check all services have another team member "
-            "with manage_settings",
+            message="User can’t be archived - check all services the user belongs to have other active team members",
         ),
     )
 
@@ -274,7 +272,7 @@ def test_archive_user_shows_error_message_if_user_cannot_be_archived(
     assert normalize_spaces(page.select_one("h1").text) == "Platform admin user"
     assert (
         normalize_spaces(page.select_one(".banner-dangerous").text)
-        == "User can’t be removed from a service - check all services have another team member with manage_settings"
+        == "User can’t be archived - check all services the user belongs to have other active team members"
     )
 
 

--- a/tests/app/main/views/test_find_users.py
+++ b/tests/app/main/views/test_find_users.py
@@ -2,7 +2,6 @@ import uuid
 
 import pytest
 from flask import url_for
-from notifications_python_client.errors import HTTPError
 
 from tests import user_json
 from tests.conftest import normalize_spaces
@@ -239,41 +238,6 @@ def test_archive_user_posts_to_user_client(
     mock_user_client.assert_called_once_with("/user/{}/archive".format(api_user_active["id"]), data=None)
 
     assert mock_events.called
-
-
-def test_archive_user_shows_error_message_if_user_cannot_be_archived(
-    client_request,
-    platform_admin_user,
-    api_user_active,
-    mocker,
-    mock_get_non_empty_organisations_and_services_for_user,
-):
-    mocker.patch(
-        "app.user_api_client.post",
-        side_effect=HTTPError(
-            response=mocker.Mock(
-                status_code=400,
-                json={
-                    "result": "error",
-                    "message": "User can’t be archived - check all services the user belongs to have other active team members",
-                },
-            ),
-            message="User can’t be archived - check all services the user belongs to have other active team members",
-        ),
-    )
-
-    client_request.login(platform_admin_user)
-    page = client_request.post(
-        "main.archive_user",
-        user_id=api_user_active["id"],
-        _follow_redirects=True,
-    )
-
-    assert normalize_spaces(page.select_one("h1").text) == "Platform admin user"
-    assert (
-        normalize_spaces(page.select_one(".banner-dangerous").text)
-        == "User can’t be archived - check all services the user belongs to have other active team members"
-    )
 
 
 def test_archive_user_does_not_create_event_if_user_client_raises_unexpected_exception(

--- a/tests/app/main/views/test_template_folders.py
+++ b/tests/app/main/views/test_template_folders.py
@@ -526,7 +526,7 @@ def test_get_manage_folder_viewing_permissions_for_users(
     assert "Test User" in page.select_one("label[for=users_with_permission-1]").text
 
 
-def test_get_manage_folder_viewing_permissions_for_users_not_visible_when_no_manage_settings_permission(
+def test_get_manage_folder_viewing_permissions_for_users_not_visible_when_no_manage_users_permission(
     client_request, active_user_with_permissions, service_one, mock_get_template_folders, mocker
 ):
     active_user_with_permissions["permissions"][SERVICE_ONE_ID] = [

--- a/tests/app/utils/test_user.py
+++ b/tests/app/utils/test_user.py
@@ -41,7 +41,7 @@ def test_permissions(
 ):
     request.view_args.update({"service_id": "foo"})
 
-    api_user_active["permissions"] = {"foo": ["manage_users", "manage_templates", "manage_settings"]}
+    api_user_active["permissions"] = {"foo": ["manage_users", "manage_templates"]}
     api_user_active["services"] = ["foo", "bar"]
 
     client_request.login(api_user_active)
@@ -149,7 +149,7 @@ def test_user_with_no_permissions_to_service_goes_to_templates(
     client_request,
     api_user_active,
 ):
-    api_user_active["permissions"] = {"foo": ["manage_users", "manage_templates", "manage_settings"]}
+    api_user_active["permissions"] = {"foo": ["manage_users", "manage_templates"]}
     api_user_active["services"] = ["foo", "bar"]
     client_request.login(api_user_active)
     request.view_args = {"service_id": "bar"}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -509,7 +509,6 @@ def platform_admin_user(fake_uuid):
             SERVICE_ONE_ID: [
                 "manage_users",
                 "manage_templates",
-                "manage_settings",
                 "manage_api_keys",
                 "view_activity",
             ]
@@ -583,7 +582,6 @@ def active_user_with_permission_to_two_services(fake_uuid):
     permissions = [
         "manage_users",
         "manage_templates",
-        "manage_settings",
         "manage_api_keys",
         "view_activity",
     ]
@@ -927,7 +925,7 @@ def sample_invite(mocker, service_one):
     from_user = service_one["users"][0]
     email_address = "invited_user@test.gov.uk"
     service_id = service_one["id"]
-    permissions = "view_activity,manage_settings,manage_users,manage_api_keys"
+    permissions = "view_activity,manage_users,manage_api_keys"
     created_at = str(datetime.now(timezone.utc))
     auth_type = "sms_auth"
     folder_permissions = []
@@ -1963,7 +1961,6 @@ def create_active_user_no_api_key_permission(with_unique_id=False):
         permissions={
             SERVICE_ONE_ID: [
                 "manage_templates",
-                "manage_settings",
                 "manage_users",
                 "view_activity",
             ]
@@ -2017,7 +2014,6 @@ def create_service_one_admin(**overrides):
             SERVICE_ONE_ID: [
                 "manage_users",
                 "manage_templates",
-                "manage_settings",
                 "manage_api_keys",
                 "view_activity",
             ]


### PR DESCRIPTION
Following this [API PR](https://github.com/alphagov/emergency-alerts-api/pull/354), the `manage_settings` permission has been removed and so I am removing instances here where it is necessary for the user to have the `manage_service` overall permission.