### PR TITLE
EAS-3166: Admin: Add utils to requirements.in to resolve/pin utils' requirements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,11 @@ fix-imports: ## Fix imports using isort
 
 .PHONY: freeze-requirements
 freeze-requirements: ## create static requirements.txt
-	${PYTHON_EXECUTABLE_PREFIX}pip3 install --upgrade setuptools pip-tools
+	${PYTHON_EXECUTABLE_PREFIX}pip3 install pip-tools
 	${PYTHON_EXECUTABLE_PREFIX}pip-compile requirements.in
+	sed -i.orig 's/emergency-alerts-utils @/# Commented out for parent requirements.txt: emergency-alerts-utils @/' requirements.txt
+# Work around macOS having awkward sed that needs an original file
+	rm requirements.txt.orig || true
 
 .PHONY: bump-utils
 bump-utils:  # Bump emergency-alerts-utils package to latest version

--- a/requirements.in
+++ b/requirements.in
@@ -24,6 +24,10 @@ urllib3==2.7.0
 Werkzeug==3.1.8
 wtforms==3.2.1
 
+# For transitive dependency resolution using pip-tools only.
+# In container builds we use the sibling (base image) version.
+emergency-alerts-utils @ git+https://github.com/alphagov/emergency-alerts-utils.git
+
 # Packages for testing
 beautifulsoup4==4.14.3
 black==26.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,16 +19,22 @@ blinker==1.9.0
     #   -r requirements.in
     #   flask
 boto3==1.38.33
-    # via moto
+    # via
+    #   dramatiq-sqs
+    #   emergency-alerts-utils
+    #   moto
 botocore==1.38.33
     # via
     #   boto3
     #   moto
     #   s3transfer
+cachetools==7.1.4
+    # via emergency-alerts-utils
 certifi==2025.4.26
     # via
     #   pyproj
     #   requests
+    #   signxml
 cffi==1.17.1
     # via cryptography
 charset-normalizer==3.4.2
@@ -41,6 +47,7 @@ cryptography==44.0.3
     # via
     #   fido2
     #   moto
+    #   signxml
 deprecated==1.3.1
     # via
     #   opentelemetry-api
@@ -50,6 +57,16 @@ deprecated==1.3.1
     #   opentelemetry-semantic-conventions
 docopt==0.6.2
     # via notifications-python-client
+dramatiq==2.2.0
+    # via
+    #   dramatiq-sqs
+    #   emergency-alerts-utils
+    #   flask-dramatiq
+    #   periodiq
+dramatiq-sqs==0.3.1
+    # via emergency-alerts-utils
+# Commented out for parent requirements.txt: emergency-alerts-utils @ git+https://github.com/alphagov/emergency-alerts-utils.git
+    # via -r requirements.in
 execnet==2.1.1
     # via pytest-xdist
 fido2==1.2.0
@@ -66,14 +83,20 @@ flake8-print==5.0.0
 flask==3.1.3
     # via
     #   -r requirements.in
+    #   emergency-alerts-utils
+    #   flask-dramatiq
     #   flask-login
     #   flask-wtf
+flask-dramatiq==0.8.0
+    # via emergency-alerts-utils
 flask-login==0.6.3
     # via -r requirements.in
 flask-wtf==1.2.2
     # via -r requirements.in
 freezegun==1.5.5
     # via -r requirements.in
+geojson==3.3.0
+    # via emergency-alerts-utils
 googleapis-common-protos==1.72.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -97,11 +120,13 @@ isort==8.0.1
 itsdangerous==2.2.0
     # via
     #   -r requirements.in
+    #   emergency-alerts-utils
     #   flask
     #   flask-wtf
 jinja2==3.1.6
     # via
     #   -r requirements.in
+    #   emergency-alerts-utils
     #   flask
     #   govuk-frontend-jinja
     #   moto
@@ -109,6 +134,10 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
+lxml==6.1.1
+    # via
+    #   emergency-alerts-utils
+    #   signxml
 markupsafe==3.0.3
     # via
     #   -r requirements.in
@@ -426,6 +455,8 @@ opentelemetry-util-http==0.54b1
     #   opentelemetry-instrumentation-urllib
     #   opentelemetry-instrumentation-urllib3
     #   opentelemetry-instrumentation-wsgi
+ordered-set==4.1.0
+    # via emergency-alerts-utils
 packaging==25.0
     # via
     #   black
@@ -437,6 +468,12 @@ packaging==25.0
     #   pytest
 pathspec==1.0.4
     # via black
+pendulum==3.2.0
+    # via periodiq
+periodiq==0.14.0
+    # via emergency-alerts-utils
+phonenumbers==9.0.33
+    # via emergency-alerts-utils
 platformdirs==4.3.8
     # via black
 pluggy==1.6.0
@@ -464,7 +501,9 @@ pygments==2.19.2
 pyjwt==2.12.1
     # via notifications-python-client
 pyproj==3.7.2
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   emergency-alerts-utils
 pytest==9.0.3
     # via
     #   -r requirements.in
@@ -482,16 +521,24 @@ python-dateutil==2.9.0.post0
     #   botocore
     #   freezegun
     #   moto
+    #   pendulum
 python-dotenv==1.2.2
     # via pytest-env
+python-json-logger==4.1.0
+    # via emergency-alerts-utils
 pytokens==0.4.1
     # via black
 pytz==2026.1.post1
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   emergency-alerts-utils
 pyyaml==6.0.2
-    # via responses
+    # via
+    #   emergency-alerts-utils
+    #   responses
 requests==2.33.0
     # via
+    #   emergency-alerts-utils
     #   govuk-bank-holidays
     #   moto
     #   notifications-python-client
@@ -507,9 +554,15 @@ rtreelib==0.2.0
 s3transfer==0.13.0
     # via boto3
 shapely==2.1.2
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   emergency-alerts-utils
+signxml==4.5.1
+    # via emergency-alerts-utils
 six==1.17.0
     # via python-dateutil
+smartypants==2.0.2
+    # via emergency-alerts-utils
 soupsieve==2.7
     # via beautifulsoup4
 typing-extensions==4.15.0
@@ -517,6 +570,8 @@ typing-extensions==4.15.0
     #   beautifulsoup4
     #   grpcio
     #   opentelemetry-sdk
+tzdata==2026.2
+    # via pendulum
 urllib3==2.7.0
     # via
     #   -r requirements.in
@@ -526,6 +581,7 @@ urllib3==2.7.0
 werkzeug==3.1.8
     # via
     #   -r requirements.in
+    #   emergency-alerts-utils
     #   flask
     #   flask-login
     #   moto
@@ -559,3 +615,6 @@ xmltodict==0.14.2
     # via moto
 zipp==3.23.0
     # via importlib-metadata
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools


### PR DESCRIPTION
We were bringing in signxml v5 in unknowingly, which has broken recent builds of admin.