### PR TITLE
EAS-3166: Change dependency installation to use sibling utils on the fly

### DIFF
--- a/.github/workflows/on-pr-into-main.yml
+++ b/.github/workflows/on-pr-into-main.yml
@@ -37,8 +37,8 @@ jobs:
 
           if [[ -n $PR_UTILS_BRANCH ]]; then
             echo "Going to use branch $PR_UTILS_BRANCH for utils"
-            sed -i "s|emergency-alerts-utils\.git|emergency-alerts-utils.git@$PR_UTILS_BRANCH|" requirements_github_utils.txt
-            cat requirements_github_utils.txt
+            sed -i "s|emergency-alerts-utils\.git|emergency-alerts-utils.git@$PR_UTILS_BRANCH|" requirements.txt
+            cat requirements.txt
           else
             echo "Leaving utils target as default"
           fi

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,11 @@ PYTHON_EXECUTABLE_PREFIX := $(shell test -d "$${VIRTUALENV_ROOT}" && echo "$${VI
 
 ## DEVELOPMENT
 .PHONY: bootstrap
-bootstrap: generate-version-file ## Set up everything to run the app
+bootstrap: generate-version-file
+# In container builds we use a sibling utils from the base image, not a specific ref from git.
+	sed -i.orig 's/emergency-alerts-utils @/# DO NOT COMMIT: Commented out for parent requirements.txt: emergency-alerts-utils @/' requirements.txt
+# Work around macOS having awkward sed that creates/requires an original file
+	rm requirements.txt.orig || true
 	${PYTHON_EXECUTABLE_PREFIX}pip3 install -r requirements_local_utils.txt
 	npm ci --no-audit
 	npm run build
@@ -24,7 +28,7 @@ bootstrap: generate-version-file ## Set up everything to run the app
 
 .PHONY: bootstrap-for-tests
 bootstrap-for-tests: generate-version-file ## Set up everything to run the tests
-	${PYTHON_EXECUTABLE_PREFIX}pip3 install -r requirements_github_utils.txt
+	${PYTHON_EXECUTABLE_PREFIX}pip3 install -r requirements.txt
 	npm ci --no-audit
 	npm run build
 
@@ -76,9 +80,6 @@ fix-imports: ## Fix imports using isort
 freeze-requirements: ## create static requirements.txt
 	${PYTHON_EXECUTABLE_PREFIX}pip3 install pip-tools
 	${PYTHON_EXECUTABLE_PREFIX}pip-compile requirements.in
-	sed -i.orig 's/emergency-alerts-utils @/# Commented out for parent requirements.txt: emergency-alerts-utils @/' requirements.txt
-# Work around macOS having awkward sed that needs an original file
-	rm requirements.txt.orig || true
 
 .PHONY: bump-utils
 bump-utils:  # Bump emergency-alerts-utils package to latest version

--- a/requirements.txt
+++ b/requirements.txt
@@ -65,7 +65,7 @@ dramatiq==2.2.0
     #   periodiq
 dramatiq-sqs==0.3.1
     # via emergency-alerts-utils
-# Commented out for parent requirements.txt: emergency-alerts-utils @ git+https://github.com/alphagov/emergency-alerts-utils.git
+emergency-alerts-utils @ git+https://github.com/alphagov/emergency-alerts-utils.git
     # via -r requirements.in
 execnet==2.1.1
     # via pytest-xdist

--- a/requirements_github_utils.txt
+++ b/requirements_github_utils.txt
@@ -1,2 +1,0 @@
--r requirements.txt
-emergency-alerts-utils @ git+https://github.com/alphagov/emergency-alerts-utils.git


### PR DESCRIPTION
#410 didn't account for Dependabot, which won't be aware of our post-update logic. Instead I've moved it to be on the fly upon installing. This does mean there'll be an uncommitted change locally though.