### PR TITLE
EAS-3104 Display Local Authority > Electoral Ward hierarchy

### DIFF
--- a/app/assets/stylesheets/views/dashboard.scss
+++ b/app/assets/stylesheets/views/dashboard.scss
@@ -48,7 +48,8 @@
 
     // note: first-child of a section should be a heading
     & > :first-child,
-    & > .area-list {
+    & > .area-list,
+    & > .area-list-section {
       width: 100%;
       text-align: left;
     }

--- a/app/templates/components/alert-summary-list.html
+++ b/app/templates/components/alert-summary-list.html
@@ -2,8 +2,7 @@
 {% from "views/broadcast/macros/enlarged-map.html" import enlarged_map %}
 {% from "views/broadcast/macros/area-map.html" import map %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
-
-
+{% from "components/electoral-ward-descriptor.html" import electoral_ward_descriptor %}
 
 {% macro alertSummaryList(is_editable, current_service, broadcast_message, areas, bleed_estimated_area, count_of_phones, count_of_phones_likely, is_custom_broadcast) %}
 
@@ -34,7 +33,7 @@
         <ul class="area-list">
         {% for area in broadcast_message.areas %}
             <li class="area-list-item area-list-item--unremoveable">
-              {% if area.is_electoral_ward and area.parent %}{{ area.parent.name }} &gt; {% endif %}{{area.name}}
+              {{ electoral_ward_descriptor(area) }}
             </li>
         {% endfor %}
         </ul>

--- a/app/templates/components/alert-summary-list.html
+++ b/app/templates/components/alert-summary-list.html
@@ -34,7 +34,7 @@
         <ul class="area-list">
         {% for area in broadcast_message.areas %}
             <li class="area-list-item area-list-item--unremoveable">
-            {{area.name}}
+              {% if area.is_electoral_ward and area.parent %}{{ area.parent.name }} &gt; {% endif %}{{area.name}}
             </li>
         {% endfor %}
         </ul>

--- a/app/templates/components/electoral-ward-descriptor.html
+++ b/app/templates/components/electoral-ward-descriptor.html
@@ -1,0 +1,3 @@
+{% macro electoral_ward_descriptor(area) %}
+  {% if area.is_electoral_ward and area.parent %}{{ area.parent.name }} &gt; {% endif %}{{area.name}}
+{%- endmacro %}

--- a/app/templates/components/template-summary-list.html
+++ b/app/templates/components/template-summary-list.html
@@ -64,7 +64,7 @@
         <ul class="area-list">
         {% for area in template.areas %}
             <li class="area-list-item area-list-item--unremoveable">
-            {{area.name}}
+              {% if area.is_electoral_ward and area.parent %}{{ area.parent.name }} &gt; {% endif %}{{area.name}}
             </li>
         {% endfor %}
         </ul>

--- a/app/templates/components/template-summary-list.html
+++ b/app/templates/components/template-summary-list.html
@@ -2,6 +2,7 @@
 {% from "views/broadcast/macros/enlarged-map.html" import enlarged_map %}
 {% from "views/broadcast/macros/area-map.html" import map %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
+{% from "components/electoral-ward-descriptor.html" import electoral_ward_descriptor %}
 
 {% macro templateSummaryList(template, areas, bleed_estimated_area, count_of_phones, count_of_phones_likely, is_custom_broadcast, formatted_template, current_user, is_editable, edit_mode) %}
 
@@ -64,7 +65,7 @@
         <ul class="area-list">
         {% for area in template.areas %}
             <li class="area-list-item area-list-item--unremoveable">
-              {% if area.is_electoral_ward and area.parent %}{{ area.parent.name }} &gt; {% endif %}{{area.name}}
+              {{ electoral_ward_descriptor(area) }}
             </li>
         {% endfor %}
         </ul>

--- a/app/templates/views/broadcast/partials/dashboard-table.html
+++ b/app/templates/views/broadcast/partials/dashboard-table.html
@@ -76,11 +76,13 @@
           </p>
         {% endif %}
         {% if item.status not in ['rejected', 'draft'] %}
-          <div>
+          <div class="area-list-section">
             <p class="govuk-!-margin-right-2 area-list">Area: </p>
             <ul class="area-list">
               {% for area in item.areas %}
-                <li class="area-list-item area-list-item--unremoveable area-list-item--smaller">{{area.name}}</li>
+                <li class="area-list-item area-list-item--unremoveable area-list-item--smaller">
+                  {% if area.is_electoral_ward and area.parent %}{{ area.parent.name }} &gt; {% endif %}{{area.name}}
+                </li>
               {% endfor %}
             </ul>
             {% if item.duration|format_seconds_duration_as_time != "0 seconds" %}
@@ -129,11 +131,13 @@
               {% endif %}
             </p>
           </div>
-          <div>
+          <div class="area-list-section">
             <p class="govuk-!-margin-right-1 area-list govuk-!-font-weight-bold">Area: </p>
             <ul class="area-list">
               {% for area in item.areas %}
-                <li class="area-list-item area-list-item--unremoveable area-list-item--smaller">{{area.name}}</li>
+                <li class="area-list-item area-list-item--unremoveable area-list-item--smaller">
++                  {% if area.is_electoral_ward and area.parent %}{{ area.parent.name }} &gt; {% endif %}{{area.name}}
++               </li>
               {% endfor %}
             </ul>
           </div>

--- a/app/templates/views/broadcast/partials/dashboard-table.html
+++ b/app/templates/views/broadcast/partials/dashboard-table.html
@@ -2,6 +2,7 @@
 {% from "components/select-input.html" import select_dropdown %}
 {% from "govuk_frontend_jinja/components/tag/macro.html" import govukTag %}
 {% from "components/form.html" import form_wrapper %}
+{% from "components/electoral-ward-descriptor.html" import electoral_ward_descriptor %}
 
 <div class="ajax-block-container js-mark-focus-on-parent" data-classes-to-persist="js-child-has-focus">
   {% if broadcasts %}
@@ -81,7 +82,7 @@
             <ul class="area-list">
               {% for area in item.areas %}
                 <li class="area-list-item area-list-item--unremoveable area-list-item--smaller">
-                  {% if area.is_electoral_ward and area.parent %}{{ area.parent.name }} &gt; {% endif %}{{area.name}}
+                  {{ electoral_ward_descriptor(area) }}
                 </li>
               {% endfor %}
             </ul>
@@ -136,7 +137,7 @@
             <ul class="area-list">
               {% for area in item.areas %}
                 <li class="area-list-item area-list-item--unremoveable area-list-item--smaller">
-                  {% if area.is_electoral_ward and area.parent %}{{ area.parent.name }} &gt; {% endif %}{{area.name}}
+                  {{ electoral_ward_descriptor(area) }}
                 </li>
               {% endfor %}
             </ul>

--- a/app/templates/views/broadcast/partials/dashboard-table.html
+++ b/app/templates/views/broadcast/partials/dashboard-table.html
@@ -136,8 +136,8 @@
             <ul class="area-list">
               {% for area in item.areas %}
                 <li class="area-list-item area-list-item--unremoveable area-list-item--smaller">
-+                  {% if area.is_electoral_ward and area.parent %}{{ area.parent.name }} &gt; {% endif %}{{area.name}}
-+               </li>
+                  {% if area.is_electoral_ward and area.parent %}{{ area.parent.name }} &gt; {% endif %}{{area.name}}
+                </li>
               {% endfor %}
             </ul>
           </div>

--- a/app/templates/views/broadcast/preview-areas.html
+++ b/app/templates/views/broadcast/preview-areas.html
@@ -4,6 +4,7 @@
 {% from "components/page-footer.html" import page_footer %}
 {% from "views/broadcast/macros/area-map.html" import map %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+{% from "components/electoral-ward-descriptor.html" import electoral_ward_descriptor %}
 
 {% set page_title %}
   {% if message_type == "broadcast" %}
@@ -49,7 +50,7 @@
       <ul class="area-list">
         {% for area in message.areas %}
           <li class="area-list-item">
-            {% if area.is_electoral_ward and area.parent %}{{ area.parent.name }} &gt; {% endif %}{{area.name}}
+            {{ electoral_ward_descriptor(area) }}
             {% if is_custom_broadcast %}
               <a class="area-list-item-remove govuk-button" data-module="govuk-button" role="button" href="{{ url_for('.remove_custom_area', service_id=current_service.id, message_id=message.id, area_slug=area.id or None, message_type=message_type) }}">
             {% else %}

--- a/app/templates/views/broadcast/preview-areas.html
+++ b/app/templates/views/broadcast/preview-areas.html
@@ -49,7 +49,7 @@
       <ul class="area-list">
         {% for area in message.areas %}
           <li class="area-list-item">
-            {{area.name}}
+            {% if area.is_electoral_ward and area.parent %}{{ area.parent.name }} &gt; {% endif %}{{area.name}}
             {% if is_custom_broadcast %}
               <a class="area-list-item-remove govuk-button" data-module="govuk-button" role="button" href="{{ url_for('.remove_custom_area', service_id=current_service.id, message_id=message.id, area_slug=area.id or None, message_type=message_type) }}">
             {% else %}

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -1207,8 +1207,8 @@ def test_broadcast_page(
                 "wd25-E05014243",
             ],
             [
-                "Penrith North Remove Penrith North",
-                "Penrith South Remove Penrith South",
+                "Westmorland and Furness > Penrith North Remove Penrith North",
+                "Westmorland and Furness > Penrith South Remove Penrith South",
             ],
             [
                 "An area of 10 square miles Will get the alert",


### PR DESCRIPTION
This PR renders area labels with the format "Local Authority > Electoral Ward". The new CSS class is added to avoid the full width rendering when labels are too big to fit side by side, as shown in the screenshot below:

<img width="398" height="208" alt="image" src="https://github.com/user-attachments/assets/21e8c15d-8295-437f-b5dd-c9602bc2c749" />

