### PR TITLE
EAS-3132: Change discard extra content to a button with POST

### DIFF
--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -331,6 +331,19 @@ def add_extra_content(service_id, broadcast_message_id):
         # When the page loads initially, the fields are populated with alerts current data
         form = AddExtraContentForm(extra_content=broadcast_message.extra_content)
         form.initial_extra_content.data = broadcast_message.extra_content
+    elif request.method == "POST" and request.form.get("remove-extra-content") is not None:
+        """
+        The user clicked the secondary button to remove the content. Do that and redirect back to the
+        alert page.
+        """
+        broadcast_message.remove_extra_content(service_id=current_service.id, broadcast_message_id=broadcast_message.id)
+        return redirect(
+            url_for(
+                ".view_current_broadcast",
+                service_id=current_service.id,
+                broadcast_message_id=broadcast_message.id,
+            )
+        )
     elif request.method == "POST" and request.form.get("overwrite-extra-content") is not None:
         """
         When the button to overwrite the current additional information data is clicked, the overwrite field is set
@@ -397,26 +410,6 @@ def add_extra_content(service_id, broadcast_message_id):
         form.extra_content.data = broadcast_message.extra_content
 
     return render_template("views/broadcast/add-extra-content.html", broadcast_message=broadcast_message, form=form)
-
-
-@main.route(
-    "/services/<uuid:service_id>/broadcast/<uuid:broadcast_message_id>/remove-extra-content", methods=["GET", "POST"]
-)
-@user_has_permissions("create_broadcasts", restrict_admin_usage=True)
-@service_has_permission("broadcast")
-def remove_extra_content(service_id, broadcast_message_id):
-    broadcast_message = BroadcastMessage.from_id(
-        broadcast_message_id,
-        service_id=current_service.id,
-    )
-    broadcast_message.remove_extra_content(service_id=current_service.id, broadcast_message_id=broadcast_message.id)
-    return redirect(
-        url_for(
-            ".view_current_broadcast",
-            service_id=current_service.id,
-            broadcast_message_id=broadcast_message.id,
-        )
-    )
 
 
 @main.route("/services/<uuid:service_id>/broadcast/<uuid:broadcast_message_id>/edit", methods=["GET", "POST"])

--- a/app/navigation.py
+++ b/app/navigation.py
@@ -115,7 +115,6 @@ class MainNavigation(Navigation):
             "view_broadcast_versions",
             "choose_extra_content",
             "add_extra_content",
-            "remove_extra_content",
         },
         "previous-broadcasts": {
             "broadcast_dashboard_previous",

--- a/app/templates/components/page-footer.html
+++ b/app/templates/components/page-footer.html
@@ -8,6 +8,9 @@
   destructive=False,
   secondary_link=False,
   secondary_link_text=None,
+  secondary_link_destructive=False,
+  secondary_link_button=False,
+  secondary_link_button_name="secondary",
   delete_link=False,
   delete_link_text="delete",
   centered_button=False,
@@ -16,7 +19,7 @@
   classes="",
   button_attributes={}
 ) %}
-  <div class="page-footer {{ classes }}">
+  <div class="page-footer govuk-button-group {{ classes }}">
     {% if button_text %}
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
 
@@ -50,8 +53,12 @@
         <a class="govuk-link govuk-link--destructive" href="{{ delete_link }}">{{ delete_link_text }}</a>
       </span>
     {% endif %}
-    {% if secondary_link and secondary_link_text %}
-      <a class="govuk-link govuk-link--no-visited-state page-footer-secondary-link" href="{{ secondary_link }}">{{ secondary_link_text }}</a>
+    {% if (secondary_link or secondary_link_button) and secondary_link_text %}
+      {% if secondary_link_button %}
+        <button class="govuk-button {% if secondary_link_destructive %}govuk-button--warning{% else %}govuk-button--secondary{% endif %} page-footer-secondary-link" name="{{ secondary_link_button_name }}">{{ secondary_link_text }}</button>
+      {% else%}
+        <a class="govuk-link govuk-link--no-visited-state page-footer-secondary-link" href="{{ secondary_link }}">{{ secondary_link_text }}</a>
+      {% endif %}
     {% endif %}
 
   </div>

--- a/app/templates/views/broadcast/add-extra-content.html
+++ b/app/templates/views/broadcast/add-extra-content.html
@@ -97,8 +97,12 @@
         </div>
         {% if not changes %}
           <div class="govuk-button-group">
-            {{ page_footer('Save and continue', button_name='continue', secondary_link=url_for('.remove_extra_content', service_id=current_service.id, broadcast_message_id=broadcast_message.id),
-            secondary_link_text='No longer required, return to alert') }}
+            {{ page_footer('Save and continue',
+              button_name='continue',
+              secondary_link_text='No longer required, return to alert',
+              secondary_link_button=True,
+              secondary_link_button_name="remove-extra-content",
+            )}}
           </div>
         {% endif %}
       </div>

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -6899,7 +6899,9 @@ def test_add_extra_content_secondary_removes_extra_content(
             "initial_extra_content": "Test Extra Content",
             "remove-extra-content": "anything",
         },
-        _follow_redirects=True,
+        _expected_redirect=url_for(
+            ".view_current_broadcast", service_id=SERVICE_ONE_ID, broadcast_message_id=fake_uuid
+        ),
     )
 
     mock_update_broadcast_message.assert_called_once_with(

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -6859,6 +6859,58 @@ def test_add_extra_content_updates_message(
     )
 
 
+def test_add_extra_content_secondary_removes_extra_content(
+    client_request,
+    service_one,
+    active_user_create_broadcasts_permission,
+    mocker,
+    fake_uuid,
+    mock_check_can_update_status,
+    mock_update_broadcast_message,
+    mock_get_broadcast_message_versions,
+):
+    """
+    Checks that when the secondary ('no longer required') button is clicked, that the extra content is removed.
+    """
+    service_one["permissions"] += ["broadcast"]
+    client_request.login(active_user_create_broadcasts_permission)
+
+    mocker.patch(
+        "app.broadcast_message_api_client.get_broadcast_message",
+        return_value=broadcast_message_json(
+            id_=fake_uuid,
+            template_id=fake_uuid,
+            created_by_id=fake_uuid,
+            service_id=SERVICE_ONE_ID,
+            status="draft",
+            extra_content="Test Extra Content",
+        ),
+    )
+    # Initial render of the page
+    client_request.get(".add_extra_content", service_id=SERVICE_ONE_ID, broadcast_message_id=fake_uuid)
+
+    # Simulate clicking the secondary button named remove-extra-content
+    client_request.post(
+        ".add_extra_content",
+        service_id=SERVICE_ONE_ID,
+        broadcast_message_id=fake_uuid,
+        _data={
+            "extra_content": "Test Extra Content",
+            "initial_extra_content": "Test Extra Content",
+            "remove-extra-content": "anything",
+        },
+        _follow_redirects=True,
+    )
+
+    mock_update_broadcast_message.assert_called_once_with(
+        service_id=SERVICE_ONE_ID,
+        broadcast_message_id=fake_uuid,
+        data={
+            "extra_content": "",
+        },
+    )
+
+
 def test_add_extra_content_keep_message_keeps_original_extra_content(
     client_request,
     service_one,

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -120,7 +120,6 @@ EXCLUDED_ENDPOINTS = tuple(
             "register_from_org_invite",
             "reject_broadcast_message",
             "remove_area",
-            "remove_extra_content",
             "remove_user_from_organisation",
             "remove_user_from_service",
             "remove_custom_area",


### PR DESCRIPTION
This avoids having a GET (under the previous link) doing a mutation. Moving to a POST without JavaScript necessitates using a form, but forms cannot be nested and as such we need to use the parent form. This means using the existing endpoint with logic to determine the secondary button has been pressed.

<img width="941" height="611" alt="image" src="https://github.com/user-attachments/assets/b9416c52-b5b8-42ea-a6a7-150b3c06c68e" />
