### PR TITLE
EAS-3123: Check permissions depending on message_type for area selection

### DIFF
--- a/app/main/views/broadcast_common.py
+++ b/app/main/views/broadcast_common.py
@@ -1,4 +1,4 @@
-from flask import flash, redirect, render_template, request, url_for
+from flask import abort, flash, redirect, render_template, request, url_for
 from notifications_python_client.errors import HTTPError
 
 from app.broadcast_areas.models import CustomBroadcastAreas
@@ -37,6 +37,7 @@ from app.utils.broadcast import (
     extract_attributes_from_custom_area,
     get_centroid_if_postcode_in_db,
     get_message_type,
+    has_permission_for_message_type,
     normalising_point,
     parse_coordinate_form_data,
     postcode_and_radius_entered,
@@ -121,6 +122,9 @@ def choose_area(
     message_type,
     message_id=None,
 ):
+    if not has_permission_for_message_type(service_id=service_id, message_type=message_type):
+        return abort(403)
+
     template_folder_id = request.args.get("template_folder_id")
     Message = get_message_type(message_type)
     message = Message.from_id_or_403(message_id, service_id=service_id) if message_id else None
@@ -235,6 +239,9 @@ def choose_area(
 @service_has_permission("broadcast")
 @user_has_any_permissions(["create_broadcasts", "manage_templates"], restrict_admin_usage=True)
 def choose_sub_area(service_id, message_type, library_slug, area_slug, message_id=None):
+    if not has_permission_for_message_type(service_id=service_id, message_type=message_type):
+        return abort(403)
+
     template_folder_id = request.args.get("template_folder_id")
     Message = get_message_type(message_type)
     message = Message.from_id_or_403(message_id, service_id=service_id) if message_id else None
@@ -334,6 +341,9 @@ def preview_areas(service_id, message_id, message_type):
 @service_has_permission("broadcast")
 @user_has_any_permissions(["create_broadcasts", "manage_templates"], restrict_admin_usage=True)
 def search_postcodes(service_id, message_type, message_id=None):
+    if not has_permission_for_message_type(service_id=service_id, message_type=message_type):
+        return abort(403)
+
     template_folder_id = request.args.get("template_folder_id")
     Message = get_message_type(message_type)
     message = Message.from_id_or_403(message_id, service_id=service_id) if message_id else None

--- a/app/utils/broadcast.py
+++ b/app/utils/broadcast.py
@@ -11,7 +11,7 @@ from shapely import Point
 from shapely.geometry import MultiPolygon, Polygon
 from shapely.ops import unary_union
 
-from app import current_service
+from app import current_service, current_user
 from app.broadcast_areas.models import (
     BaseBroadcastArea,
     CustomBroadcastArea,
@@ -681,6 +681,15 @@ def get_message_type(message_type):
         "broadcast": BroadcastMessage,
         "templates": Template,
     }[message_type]
+
+
+def has_permission_for_message_type(service_id: str, message_type: str) -> bool:
+    if message_type == "broadcast":
+        return current_user.has_permission_for_service(service_id, "create_broadcasts")
+    elif message_type == "templates":
+        return current_user.has_permission_for_service(service_id, "manage_templates")
+    else:
+        raise RuntimeError("No known message_type " + message_type)
 
 
 def generate_geojson(broadcast_message):

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -318,6 +318,90 @@ def test_broadcast_pages_403_for_user_without_permission(
 
 
 @pytest.mark.parametrize(
+    "endpoint, endpoint_params, endpoint_data",
+    (
+        (".search_postcodes", {}, {"postcode": "BD1 1EE", "radius": "2", "continue": True}),
+        (".choose_area", {"library_slug": "countries"}, {"postcode": "BD1 1EE", "radius": "2", "continue": True}),
+        (
+            ".choose_sub_area",
+            {"library_slug": "wd25-lad25-ctyua25", "area_slug": "ctyua25-E10000016"},
+            {"postcode": "BD1 1EE", "radius": "2", "continue": True},
+        ),
+    ),
+)
+def test_template_area_pages_error_for_user_with_only_create_broadcasts_permission(
+    client_request,
+    service_one,
+    mock_get_draft_broadcast_message,
+    mock_update_broadcast_message,
+    fake_uuid,
+    mocker,
+    active_user_create_broadcasts_permission,
+    mock_get_broadcast_message_versions,
+    endpoint,
+    endpoint_params,
+    endpoint_data,
+):
+    """
+    The endpoints/logic is shared for templates and broadcasts, but the permissions for each are
+    defined separately.
+    """
+
+    client_request.login(active_user_create_broadcasts_permission)
+    client_request.post(
+        endpoint,
+        service_id=SERVICE_ONE_ID,
+        message_id=fake_uuid,
+        message_type="templates",
+        **endpoint_params,
+        _data=endpoint_data,
+        _expected_status=403,
+    )
+
+
+@pytest.mark.parametrize(
+    "endpoint, endpoint_params, endpoint_data",
+    (
+        (".search_postcodes", {}, {"postcode": "BD1 1EE", "radius": "2", "continue": True}),
+        (".choose_area", {"library_slug": "countries"}, {"postcode": "BD1 1EE", "radius": "2", "continue": True}),
+        (
+            ".choose_sub_area",
+            {"library_slug": "wd25-lad25-ctyua25", "area_slug": "ctyua25-E10000016"},
+            {"postcode": "BD1 1EE", "radius": "2", "continue": True},
+        ),
+    ),
+)
+def test_broadcast_area_pages_error_for_user_with_only_manage_templates_permission(
+    client_request,
+    service_one,
+    mock_get_draft_broadcast_message,
+    mock_update_broadcast_message,
+    fake_uuid,
+    mocker,
+    active_user_manage_template_permissions,
+    mock_get_broadcast_message_versions,
+    endpoint,
+    endpoint_params,
+    endpoint_data,
+):
+    """
+    The endpoints/logic is shared for templates and broadcasts, but the permissions for each are
+    defined separately.
+    """
+
+    client_request.login(active_user_manage_template_permissions)
+    client_request.post(
+        endpoint,
+        service_id=SERVICE_ONE_ID,
+        message_id=fake_uuid,
+        message_type="broadcast",
+        **endpoint_params,
+        _data=endpoint_data,
+        _expected_status=403,
+    )
+
+
+@pytest.mark.parametrize(
     "user",
     [
         create_active_user_view_permissions(),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1982,6 +1982,11 @@ def create_active_user_no_settings_permission(with_unique_id=False):
     )
 
 
+@pytest.fixture(scope="function")
+def active_user_manage_template_permissions():
+    return create_active_user_manage_template_permissions()
+
+
 def create_active_user_manage_template_permissions(with_unique_id=False):
     return create_service_one_user(
         id=str(uuid4()) if with_unique_id else sample_uuid(),


### PR DESCRIPTION
The ticket/finding description was a little hard to find at first, but I think I've settled on what it meant here. It might need revisiting in a future run but at that point it might be melded up together with the other 'API trusts admin' themes.