### PR TITLE
EAS-3135: Ensure broadcast/.../submit is always used as a POST

### DIFF
--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -642,7 +642,7 @@ def preview_broadcast_message(service_id, broadcast_message_id):
     return render_preview_alert_page(broadcast_message, is_custom_broadcast, areas)
 
 
-@main.route("/services/<uuid:service_id>/broadcast/<uuid:broadcast_message_id>/submit", methods=["GET", "POST"])
+@main.route("/services/<uuid:service_id>/broadcast/<uuid:broadcast_message_id>/submit", methods=["POST"])
 @user_has_permissions("create_broadcasts", restrict_admin_usage=True)
 @service_has_permission("broadcast")
 def submit_broadcast_message(service_id, broadcast_message_id):

--- a/app/templates/views/broadcast/view-message.html
+++ b/app/templates/views/broadcast/view-message.html
@@ -352,16 +352,17 @@
 ) %}
 
 {% if can_submit_for_approval %}
-  {{ govukButton({
-    "element": "a",
-    "text": "Submit for approval",
-    "href":url_for(
+  {% call form_wrapper(action=url_for(
       ".submit_broadcast_message",
       service_id=current_service.id,
       broadcast_message_id=broadcast_message.id,
-    ),
-    "classes": "govuk-button"
-  }) }}
+    )) %}
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+    {{ govukButton({
+      "text": "Submit for approval",
+      "classes": "govuk-button"
+    }) }}
+  {% endcall %}
 {% endif %}
 
 {% if broadcast_message.status in ["draft", "returned"] and broadcast_message_version_count > 1 %}

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -516,7 +516,7 @@ def test_view_broadcast_page_displays_error_if_area_invalid(
         "to the Emergency Alerts team."
     )
 
-    submitted_alert_page = client_request.get(
+    submitted_alert_page = client_request.post(
         ".submit_broadcast_message", service_id=SERVICE_ONE_ID, broadcast_message_id=fake_uuid, _expected_status=200
     )
 
@@ -6245,7 +6245,7 @@ def test_cannot_submit_if_transition_not_allowed(
 
     client_request.login(create_active_user_create_broadcasts_permissions())
 
-    page = client_request.get(
+    page = client_request.post(
         ".submit_broadcast_message", service_id=SERVICE_ONE_ID, broadcast_message_id=fake_uuid, _expected_status=200
     )
 


### PR DESCRIPTION
'Submit for approval' on the preview page (I'm not sure why we have the distinction - they seem very similar) uses a POST button via `page_footer` already, so this just makes sure we use a button in a similar pattern by wrapping it in an empty form so we get the browser to POST there too.