### PR TITLE
EAS-3136: Change 'Discard this alert' to a button that always POSTs

### DIFF
--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -864,7 +864,7 @@ def return_broadcast_for_edit(service_id, broadcast_message_id):
     )
 
 
-@main.route("/services/<uuid:service_id>/broadcast/<uuid:broadcast_message_id>/discard", methods=["GET", "POST"])
+@main.route("/services/<uuid:service_id>/broadcast/<uuid:broadcast_message_id>/discard", methods=["POST"])
 @user_has_permissions("create_broadcasts", "approve_broadcasts", restrict_admin_usage=True)
 @service_has_permission("broadcast")
 def discard_broadcast_message(service_id, broadcast_message_id):

--- a/app/templates/components/page-footer.html
+++ b/app/templates/components/page-footer.html
@@ -57,7 +57,7 @@
       {% if secondary_link_button %}
         <button class="govuk-button {% if secondary_link_destructive %}govuk-button--warning{% else %}govuk-button--secondary{% endif %} page-footer-secondary-link" name="{{ secondary_link_button_name }}">{{ secondary_link_text }}</button>
       {% else%}
-        <a class="govuk-link govuk-link--no-visited-state page-footer-secondary-link" href="{{ secondary_link }}">{{ secondary_link_text }}</a>
+        <a class="govuk-link govuk-link--no-visited-state {% if secondary_link_destructive %}govuk-link--destructive{% endif %} page-footer-secondary-link" href="{{ secondary_link }}">{{ secondary_link_text }}</a>
       {% endif %}
     {% endif %}
 

--- a/app/templates/views/broadcast/view-message.html
+++ b/app/templates/views/broadcast/view-message.html
@@ -76,6 +76,21 @@
   </div>
 {% endset %}
 
+{% set discard_alert_html %}
+  {% call form_wrapper(action=url_for(
+      'main.discard_broadcast_message',
+      service_id=current_service.id,
+      broadcast_message_id=broadcast_message.id
+  )) %}
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+    {{ page_footer(
+        secondary_link_button=True,
+        secondary_link_destructive=True,
+        secondary_link_text='Discard this alert'
+    ) }}
+  {% endcall %}
+{% endset %}
+
 {% set approve_details %}
   <div class="govuk-!-margin-bottom-5">
     {% call form_wrapper(id='approve') %}
@@ -122,9 +137,7 @@
           <p class="govuk-body govuk-!-margin-top-2 govuk-!-margin-bottom-3">
             This alert cannot be approved.
           </p>
-          <span class="page-footer-link page-footer-delete-link-without-button">
-            <a class="govuk-link govuk-link--destructive" href="{{ url_for('main.discard_broadcast_message', service_id=current_service.id, broadcast_message_id=broadcast_message.id) }}">Discard this alert</a>
-          </span>
+          {{ discard_alert_html }}
         </div>
     {% elif broadcast_message.created_by_id and broadcast_message.created_by_id == current_user.id
       and current_user.has_permissions('create_broadcasts', 'approve_broadcasts', restrict_admin_usage=True) %}
@@ -177,10 +190,7 @@
             <p class="govuk-body">
               You need another member of your team to approve your alert.
             </p>
-            {{ page_footer(
-              delete_link=url_for('main.discard_broadcast_message', service_id=current_service.id, broadcast_message_id=broadcast_message.id),
-              delete_link_text='Discard this alert'
-            ) }}
+            {{ discard_alert_html }}
           {% elif current_user.has_permissions('approve_broadcasts', restrict_admin_usage=True) %}
             <p class="govuk-body govuk-!-margin-bottom-3">
               When you use a live account you’ll need another member of
@@ -217,10 +227,7 @@
             <p class="govuk-body">
               This service is in training mode. No real alerts will be sent.
             </p>
-            {{ page_footer(
-              delete_link=url_for('main.discard_broadcast_message', service_id=current_service.id, broadcast_message_id=broadcast_message.id),
-              delete_link_text='Discard this alert'
-            ) }}
+            {{ discard_alert_html }}
           {% endif %}
         </div>
       {% endif %}
@@ -234,10 +241,7 @@
         <p class="govuk-body">
           You need another member of your team to approve your alert.
         </p>
-        {{ page_footer(
-          delete_link=url_for('main.discard_broadcast_message', service_id=current_service.id, broadcast_message_id=broadcast_message.id),
-          delete_link_text='Discard this alert'
-        ) }}
+        {{ discard_alert_html }}
       </div>
     {% elif current_user.has_permissions('approve_broadcasts', restrict_admin_usage=True) %}
       <div class="banner govuk-!-margin-bottom-6">
@@ -296,10 +300,7 @@
             This service is in training mode. No real alerts will be sent.
           </p>
         {% endif %}
-        {{ page_footer(
-          delete_link=url_for('main.discard_broadcast_message', service_id=current_service.id, broadcast_message_id=broadcast_message.id),
-          delete_link_text='Discard this alert'
-          ) }}
+        {{ discard_alert_html }}
       </div>
     {% else %}
       <div class="banner govuk-!-margin-bottom-6">

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -5333,11 +5333,11 @@ def test_cannot_approve_own_broadcast_if_service_is_live_and_user_submitted_aler
     assert (normalize_spaces(page.select_one(".banner p").text)) == (
         "You need another member of your team to approve your alert."
     )
-    assert not page.select("form")
 
-    link = page.select_one(".banner a.govuk-link.govuk-link--destructive")
-    assert link.text == "Discard this alert"
-    assert link["href"] == url_for(
+    button = page.select_one(".banner button.govuk-button.govuk-button--warning")
+    assert button.text == "Discard this alert"
+    form = button.parent.parent
+    assert form["action"] == url_for(
         ".discard_broadcast_message",
         service_id=SERVICE_ONE_ID,
         broadcast_message_id=fake_uuid,
@@ -5501,10 +5501,13 @@ def test_user_without_approve_permission_cant_approve_broadcast_created_by_someo
     )
 
     assert (normalize_spaces(page.select_one(".banner").text)) == banner_text
-    assert not page.select_one("form")
-    link = page.select_one(".banner a")
-    assert link["href"] == url_for(
-        ".discard_broadcast_message", service_id=SERVICE_ONE_ID, broadcast_message_id=fake_uuid
+    button = page.select_one(".banner button.govuk-button.govuk-button--warning")
+    assert button.text == "Discard this alert"
+    form = button.parent.parent
+    assert form["action"] == url_for(
+        ".discard_broadcast_message",
+        service_id=SERVICE_ONE_ID,
+        broadcast_message_id=fake_uuid,
     )
 
 
@@ -5550,9 +5553,10 @@ def test_user_without_approve_permission_cant_approve_broadcast_they_created(
     )
     assert not page.select(".banner input[type=checkbox]")
 
-    link = page.select_one("a.govuk-link.govuk-link--destructive")
-    assert link.text == "Discard this alert"
-    assert link["href"] == url_for(
+    button = page.select_one(".banner button.govuk-button.govuk-button--warning")
+    assert button.text == "Discard this alert"
+    form = button.parent.parent
+    assert form["action"] == url_for(
         ".discard_broadcast_message",
         service_id=SERVICE_ONE_ID,
         broadcast_message_id=fake_uuid,
@@ -5953,9 +5957,10 @@ def test_discard_broadcast(
     page = client_request.post(
         ".reject_broadcast_message", service_id=SERVICE_ONE_ID, broadcast_message_id=fake_uuid, _expected_status=200
     )
-    link = page.select_one(".banner a.govuk-link.govuk-link--destructive")
-    assert link.text == "Discard this alert"
-    assert link["href"] == url_for(
+    button = page.select_one(".banner button.govuk-button.govuk-button--warning")
+    assert button.text == "Discard this alert"
+    form = button.parent.parent
+    assert form["action"] == url_for(
         ".discard_broadcast_message",
         service_id=SERVICE_ONE_ID,
         broadcast_message_id=fake_uuid,
@@ -6245,7 +6250,7 @@ def test_cannot_submit_if_transition_not_allowed(
 
     client_request.login(create_active_user_create_broadcasts_permissions())
 
-    page = client_request.get(
+    page = client_request.post(
         ".submit_broadcast_message", service_id=SERVICE_ONE_ID, broadcast_message_id=fake_uuid, _expected_status=200
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import copy
 import json
 import os
+from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from datetime import date, datetime, timedelta, timezone
 from functools import partial
@@ -1123,20 +1124,44 @@ def os_environ():
         os.environ[k] = v
 
 
+class ClientRequest(ABC):
+    """
+    See ClientRequestImpl - this is just an abstract for type hinting responses into a
+    BeautifulSoup instance for autocomplete when writing tests.
+    """
+
+    @abstractmethod
+    def get(
+        endpoint,
+        _expected_status=200,
+        _follow_redirects=False,
+        _expected_redirect=None,
+        _test_page_title=True,
+        _test_page_prefix=None,
+        _test_for_elements_without_class=True,
+        _optional_args="",
+        **endpoint_kwargs,
+    ) -> NotifyBeautifulSoup:
+        pass
+
+    @abstractmethod
+    def post(
+        endpoint,
+        _data=None,
+        _expected_status=None,
+        _follow_redirects=False,
+        _expected_redirect=None,
+        _content_type=None,
+        **endpoint_kwargs,
+    ) -> NotifyBeautifulSoup:
+        pass
+
+
 @pytest.fixture  # noqa (C901 too complex)
-def client_request(_logged_in_client, mocker, service_one):  # noqa (C901 too complex)
+def client_request(_logged_in_client, mocker, service_one) -> ClientRequest:  # noqa (C901 too complex)
     mocker.patch("app.feature_toggle_api_client.get_feature_toggle", return_value={})
 
-    def block_method(object, method_name, preferred_method_name):
-        def blocked_method(*args, **kwargs):
-            raise AttributeError(
-                f"Don’t use {object.__class__.__name__}.{method_name}"
-                f" – try {object.__class__.__name__}.{preferred_method_name} instead"
-            )
-
-        setattr(object, method_name, blocked_method)
-
-    class ClientRequest:
+    class ClientRequestImpl(ClientRequest):
         @staticmethod
         @contextmanager
         def session_transaction():
@@ -1163,7 +1188,7 @@ def client_request(_logged_in_client, mocker, service_one):  # noqa (C901 too co
             _optional_args="",
             **endpoint_kwargs,
         ):
-            return ClientRequest.get_url(
+            return ClientRequestImpl.get_url(
                 url_for(endpoint, **(endpoint_kwargs or {})) + _optional_args,
                 _expected_status=_expected_status,
                 _follow_redirects=_follow_redirects,
@@ -1242,7 +1267,7 @@ def client_request(_logged_in_client, mocker, service_one):  # noqa (C901 too co
             _content_type=None,
             **endpoint_kwargs,
         ):
-            return ClientRequest.post_url(
+            return ClientRequestImpl.post_url(
                 url_for(endpoint, **(endpoint_kwargs or {})),
                 _data=_data,
                 _expected_status=_expected_status,
@@ -1274,7 +1299,7 @@ def client_request(_logged_in_client, mocker, service_one):  # noqa (C901 too co
 
         @staticmethod
         def get_response(endpoint, _expected_status=200, _optional_args="", **endpoint_kwargs):
-            return ClientRequest.get_response_from_url(
+            return ClientRequestImpl.get_response_from_url(
                 url_for(endpoint, **(endpoint_kwargs or {})) + _optional_args,
                 _expected_status=_expected_status,
             )
@@ -1292,7 +1317,7 @@ def client_request(_logged_in_client, mocker, service_one):  # noqa (C901 too co
         def post_response(
             endpoint, _data=None, _expected_status=302, _optional_args="", _content_type=None, **endpoint_kwargs
         ):
-            return ClientRequest.post_response_from_url(
+            return ClientRequestImpl.post_response_from_url(
                 url_for(endpoint, **(endpoint_kwargs or {})) + _optional_args,
                 _data=_data,
                 _content_type=_content_type,
@@ -1313,7 +1338,7 @@ def client_request(_logged_in_client, mocker, service_one):  # noqa (C901 too co
             assert resp.status_code == _expected_status
             return resp
 
-    return ClientRequest
+    return ClientRequestImpl
 
 
 def normalize_spaces(input):


### PR DESCRIPTION
The finding was entirely right: this seemingly has always been a link/GET that causes a mutation. I've changed this to a form and button instead of an anchor.

But this does mean it's now an actual button (similar to #416) as design system guidelines hint we should not style buttons and links to be similar. The extra top margin is _not_ intentional, but a side effect of it being a 'secondary link' as we seem to be abusing `page_footer` a bit: though if I force it to have no margin looks way too squished to the text above compared to the link before. Happy to tweak somehow but CSS is far from my forte and I'm not sure of half of the class structure we have already.

Before:
<img width="908" height="528" alt="image" src="https://github.com/user-attachments/assets/8bb6a611-c878-46a2-ac09-671f9ed3ec75" />

After:
<img width="901" height="541" alt="image" src="https://github.com/user-attachments/assets/bace81c7-4fd5-4cb1-8619-5d94a1d1d0e3" />

