### PR TITLE
EAS-3150: dss cand 031 update password reset api

### DIFF
--- a/app/main/views/new_password.py
+++ b/app/main/views/new_password.py
@@ -52,7 +52,12 @@ def new_password(token):
                 form.password.errors.append(e.message[0])
                 return render_template("views/new-password.html", token=token, form=form, user=user)
         user.reset_failed_login_count()
-        session["user_details"] = {"id": user.id, "email": user.email_address, "password": form.password.data}
+        session["user_details"] = {
+            "id": user.id,
+            "email": user.email_address,
+            "password": form.password.data,
+            "token": token,
+        }
         if user.email_auth:
             # they've just clicked an email link, so have done an email auth journey anyway. Just log them in.
             return log_in_user(user.id)

--- a/app/main/views/user_profile.py
+++ b/app/main/views/user_profile.py
@@ -215,7 +215,7 @@ def user_profile_password():
                     return render_template("views/user-profile/change-password.html", form=form)
             try:
                 user_api_client.update_password(
-                    current_user.id, password=form.new_password.data, oldpassword=form.old_password.data
+                    current_user.id, form.new_password.data, oldpassword=form.old_password.data
                 )
             except HTTPError as e:
                 field = e.message[0].get("field", "new_password")

--- a/app/main/views/user_profile.py
+++ b/app/main/views/user_profile.py
@@ -213,7 +213,15 @@ def user_profile_password():
                 if e.status_code == 400:
                     form.new_password.errors.append(e.message[0])
                     return render_template("views/user-profile/change-password.html", form=form)
-            user_api_client.update_password(current_user.id, password=form.new_password.data)
+            try:
+                user_api_client.update_password(
+                    current_user.id, password=form.new_password.data, oldpassword=form.old_password.data
+                )
+            except HTTPError as e:
+                field = e.message[0].get("field", "new_password")
+                message = e.message[0].get("message")
+                getattr(form, field).errors.append(message)
+                return render_template("views/user-profile/change-password.html", form=form)
             return redirect(url_for(".user_profile"))
     except HTTPError as e:
         if e.status_code == 400:

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -120,8 +120,8 @@ class User(BaseUser, UserMixin):
         response = user_api_client.update_user_attribute(self.id, **kwargs)
         self.__init__(response)
 
-    def update_password(self, password):
-        response = user_api_client.update_password(self.id, password)
+    def update_password(self, password, token):
+        response = user_api_client.update_password(self.id, password, token=token)
         self.__init__(response)
 
     def update_email_access_validated_at(self):

--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -84,8 +84,12 @@ class UserApiClient(AdminAPIClient):
         user_data = self.post(url, data={})
         return user_data["data"]
 
-    def update_password(self, user_id, password, oldpassword):
-        data = {"_password": password, "_oldpassword": oldpassword}
+    def update_password(self, user_id, password, *, oldpassword=None, token=None):
+        data = {"_password": password}
+        if oldpassword is not None:
+            data["_oldpassword"] = oldpassword
+        if token is not None:
+            data["_token"] = token
         url = "/user/{}/update-password".format(user_id)
         user_data = self.post(url, data=data)
         return user_data["data"]

--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -84,8 +84,8 @@ class UserApiClient(AdminAPIClient):
         user_data = self.post(url, data={})
         return user_data["data"]
 
-    def update_password(self, user_id, password):
-        data = {"_password": password}
+    def update_password(self, user_id, password, oldpassword):
+        data = {"_password": password, "_oldpassword": oldpassword}
         url = "/user/{}/update-password".format(user_id)
         user_data = self.post(url, data=data)
         return user_data["data"]

--- a/app/utils/login.py
+++ b/app/utils/login.py
@@ -27,7 +27,7 @@ def log_in_user(user_id):
         session["session_start_utc"] = str(datetime.now(timezone.utc))
         # Check if coming from new password page
         if "password" in session.get("user_details", {}):
-            user.update_password(session["user_details"]["password"])
+            user.update_password(session["user_details"]["password"], session["user_details"]["token"])
             user.activate()
             # User activated if necessary and redirected to login again
             return redirect(url_for(".sign_in", reset_password=True))

--- a/tests/app/main/views/test_new_password.py
+++ b/tests/app/main/views/test_new_password.py
@@ -1,4 +1,5 @@
 import json
+import urllib.parse
 from datetime import datetime, timezone
 
 import pytest
@@ -171,6 +172,8 @@ def test_should_sign_in_when_password_reset_is_successful_for_email_auth(
 
     # the log-in flow makes a couple of calls
     mock_get_user.assert_called_once_with(user["id"])
-    mock_update_user_password.assert_called_once_with(user["id"], "a-new_password_123")
+    mock_update_user_password.assert_called_once_with(
+        user["id"], "a-new_password_123", token=urllib.parse.unquote(token)
+    )
 
     assert not mock_send_verify_code.called

--- a/tests/app/main/views/test_two_factor.py
+++ b/tests/app/main/views/test_two_factor.py
@@ -218,6 +218,7 @@ def test_two_factor_sms_should_set_password_when_new_password_exists_in_session(
             "id": api_user_active["id"],
             "email": api_user_active["email_address"],
             "password": "changedpassword",
+            "token": "mytoken",
         }
 
     client_request.post(
@@ -226,10 +227,7 @@ def test_two_factor_sms_should_set_password_when_new_password_exists_in_session(
         _expected_redirect=url_for("main.sign_in", reset_password=True),
     )
 
-    mock_update_user_password.assert_called_once_with(
-        api_user_active["id"],
-        "changedpassword",
-    )
+    mock_update_user_password.assert_called_once_with(api_user_active["id"], "changedpassword", token="mytoken")
 
 
 def test_two_factor_sms_returns_error_when_user_is_locked(

--- a/tests/app/notify_client/test_user_client.py
+++ b/tests/app/notify_client/test_user_client.py
@@ -60,11 +60,18 @@ def test_client_only_updates_allowed_attributes(mocker):
 
 def test_client_updates_password_separately(mocker, api_user_active):
     expected_url = "/user/{}/update-password".format(api_user_active["id"])
-    expected_params = {"_password": "newpassword"}
+    expected_params = {
+        "_password": "newpassword",
+        "_oldpassword": "oldpassword123",
+    }
     user_api_client.max_failed_login_count = 1  # doesn't matter for this test
     mock_update_password = mocker.patch("app.notify_client.user_api_client.UserApiClient.post")
 
-    user_api_client.update_password(api_user_active["id"], expected_params["_password"])
+    user_api_client.update_password(
+        api_user_active["id"],
+        password=expected_params["_password"],
+        oldpassword=expected_params["_oldpassword"],
+    )
     mock_update_password.assert_called_once_with(expected_url, data=expected_params)
 
 
@@ -143,7 +150,8 @@ def test_client_converts_admin_permissions_to_db_permissions_on_add_to_service(n
         (user_api_client, "update_user_attribute", [user_id], {}),
         (user_api_client, "reset_failed_login_count", [user_id], {}),
         (user_api_client, "update_user_attribute", [user_id], {}),
-        (user_api_client, "update_password", [user_id, "hunter2"], {}),
+        (user_api_client, "update_password", [user_id], {"password": "hunter2", "oldpassword": "hunter3"}),
+        (user_api_client, "update_password", [user_id], {"password": "hunter2", "token": "mytoken"}),
         (user_api_client, "verify_password", [user_id, "hunter2"], {}),
         (user_api_client, "check_verify_code", [user_id, "", ""], {}),
         (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -773,7 +773,7 @@ def mock_verify_password(mocker):
 
 @pytest.fixture(scope="function")
 def mock_update_user_password(mocker, api_user_active):
-    def _update(user_id, password):
+    def _update(user_id, password, oldpassword=None, token=None):
         api_user_active["id"] = user_id
         return api_user_active
 


### PR DESCRIPTION
Either pass the old password, or the password reset token through to the API when making an update_password API call.

Old password is passed to API when a user changes their password from the User Profile admin screen.

Token is passed to API when a user logs in from a password reset link.

Similar checks are then performed in the API to the admin application, to ensure update_password requests are valid.