### PR TITLE
EAS-3163 Status endpoint in API has changed

### DIFF
--- a/app/notify_client/status_api_client.py
+++ b/app/notify_client/status_api_client.py
@@ -3,7 +3,7 @@ from app.notify_client import AdminAPIClient
 
 class StatusApiClient(AdminAPIClient):
     def get_status(self, *params):
-        return self.get(*params, url="/_api_status")
+        return self.get(*params, url="/_api_status/full")
 
     def get_count_of_live_services_and_organisations(self):
         return self.get(url="/_api_status/live-service-and-organisation-counts")


### PR DESCRIPTION
API now makes a distinction between the "light" status request requiring no authentication and the "full" status request which requires authentication and returns the app and db version information in the payload.