### PR TITLE
EAS-3077: Admin: Add support for retry-exhausted operator status

### DIFF
--- a/app/formatters.py
+++ b/app/formatters.py
@@ -413,11 +413,17 @@ def split_text_by_newline(input):
 
 
 def format_provider_status_with_human_time(status, date):
+    """
+    Return something like "Sending since 7:14pm" or "Failed at 8:19pm"
+    """
+
+    # See BROADCAST_PROVIDER_STATUS_* in API
     status_mapping = {
         "technical-failure": "Failed ",  # Unused as of writing
         "sending": "Sending ",
         "returned-ack": "Sent ",
-        "returned-error": "Failed ",
+        "returned-error": "Sending, last attempted ",
+        "returned-error-retry-exhausted": "Sending failed ",
     }
 
     # Say "sending since"

--- a/app/utils/broadcast.py
+++ b/app/utils/broadcast.py
@@ -579,7 +579,7 @@ def provider_statuses_contains_fail_to_send(provider_statuses):
         alert_statuses = provider_statuses[mno].get("alert", [])
         if len(alert_statuses) > 0:
             latest_alert_status = alert_statuses[-1]
-            if latest_alert_status["status"] == "returned-error":
+            if latest_alert_status["status"] in {"returned-error", "returned-error-retry-exhausted"}:
                 return True
 
     return False

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -4472,7 +4472,7 @@ def test_start_broadcasting(
                 "approved_by": "Bob",
             },
             sending_failure_statuses,
-            "Operator Statuses Operator Alert Status EE Failed today at 11:23:23pm O2 Three Vodafone",
+            "Operator Statuses Operator Alert Status EE Sending, last attempted today at 11:23:23pm O2 Three Vodafone",
             [
                 "sending error live since 20 February at 8:20pm Stop sending",
                 "More than 1 million phones estimated",
@@ -4533,7 +4533,7 @@ def test_start_broadcasting(
                 "approved_by": "Bob",
             },
             sending_failure_statuses,
-            "Operator Statuses Operator Alert Status EE Failed today at 11:23:23pm O2 Three Vodafone",
+            "Operator Statuses Operator Alert Status EE Sending, last attempted today at 11:23:23pm O2 Three Vodafone",
             [
                 "sending error Sent on 20 February at 8:20:20pm.",
                 "More than 1 million phones estimated",


### PR DESCRIPTION
> Requires https://github.com/alphagov/emergency-alerts-api/pull/389

This uses the new 'retry exhausted' status to hint that sending has completely failed vs. being 'last attempted' via all of the DLQ trickery in the linked PR. The wording on the latter could be worth improving; do we need to give the number of times it's been attempted?

> This was running on my local via an actual DLQ with no manual database mangling!

When a send has failed but it's not yet reached the DLQ:
<img width="684" height="299" alt="image" src="https://github.com/user-attachments/assets/4776c9f9-51b1-4824-8df3-1276d89a73e2" />

After hitting the DLQ, the dlq-watcher container adds a 'retry exhausted' status which gives this:
<img width="750" height="301" alt="image" src="https://github.com/user-attachments/assets/78721e8a-f171-4623-bfba-85dfd0013192" />
