### PR TITLE
EAS-1325: send map preview with summary email

### DIFF
--- a/app/broadcast_areas/models.py
+++ b/app/broadcast_areas/models.py
@@ -44,15 +44,6 @@ class BaseBroadcastArea(ABC):
             return polygons[0].wkt
         return MultiPolygon(polygons).wkt
 
-    @property
-    def as_wkt_geometry_with_bleed(self):
-        polygons = []
-        for ring in self.simple_polygons_with_bleed.as_coordinate_pairs_long_lat:
-            polygons.append(Polygon(ring))
-        if len(polygons) == 1:
-            return polygons[0].wkt
-        return MultiPolygon(polygons).wkt
-
     @cached_property
     def simple_polygons_with_bleed(self) -> Polygons:
         return self.simple_polygons.bleed_by(self.estimated_bleed_in_m)

--- a/app/broadcast_areas/models.py
+++ b/app/broadcast_areas/models.py
@@ -44,6 +44,15 @@ class BaseBroadcastArea(ABC):
             return polygons[0].wkt
         return MultiPolygon(polygons).wkt
 
+    @property
+    def as_wkt_geometry_with_bleed(self):
+        polygons = []
+        for ring in self.simple_polygons_with_bleed.as_coordinate_pairs_long_lat:
+            polygons.append(Polygon(ring))
+        if len(polygons) == 1:
+            return polygons[0].wkt
+        return MultiPolygon(polygons).wkt
+
     @cached_property
     def simple_polygons_with_bleed(self) -> Polygons:
         return self.simple_polygons.bleed_by(self.estimated_bleed_in_m)

--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -42,6 +42,7 @@ from app.utils.broadcast import (
     format_areas_list,
     generate_geojson,
     generate_unsigned_xml,
+    generate_wkt,
     get_alert_redirect_url,
     get_changed_alert_form_data,
     get_changed_extra_content_form_data,
@@ -1134,6 +1135,9 @@ def alert_summary_email(service_id, broadcast_message_id):
             alert_summary=form.alert_summary.data,
             phone_estimate=phone_estimate,
             duration=duration_display,
+            approx_bleed_in_m=broadcast_message.simple_polygons.approx_bleed_in_m,
+            wkt=generate_wkt(broadcast_message),
+            wkt_with_bleed=generate_wkt(broadcast_message, True),
         )
         return render_current_alert_page(broadcast_message)
 

--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -1135,9 +1135,7 @@ def alert_summary_email(service_id, broadcast_message_id):
             alert_summary=form.alert_summary.data,
             phone_estimate=phone_estimate,
             duration=duration_display,
-            approx_bleed_in_m=broadcast_message.simple_polygons.approx_bleed_in_m,
             wkt=generate_wkt(broadcast_message),
-            wkt_with_bleed=generate_wkt(broadcast_message, True),
         )
         return render_current_alert_page(broadcast_message)
 

--- a/app/models/broadcast_message.py
+++ b/app/models/broadcast_message.py
@@ -299,7 +299,19 @@ class BroadcastMessage(BaseBroadcast):
 
     @classmethod
     def send_alert_summary_email(
-        cls, *, service_id, broadcast_message_id, geojson, cap_xml, ibag_xml, alert_summary, phone_estimate, duration
+        cls,
+        *,
+        service_id,
+        broadcast_message_id,
+        geojson,
+        cap_xml,
+        ibag_xml,
+        alert_summary,
+        phone_estimate,
+        duration,
+        approx_bleed_in_m,
+        wkt,
+        wkt_with_bleed
     ):
         broadcast_message_api_client.send_alert_summary_email(
             service_id=service_id,
@@ -310,6 +322,9 @@ class BroadcastMessage(BaseBroadcast):
             alert_summary=alert_summary,
             phone_estimate=phone_estimate,
             duration=duration,
+            approx_bleed_in_m=approx_bleed_in_m,
+            wkt=wkt,
+            wkt_with_bleed=wkt_with_bleed,
         )
 
 

--- a/app/models/broadcast_message.py
+++ b/app/models/broadcast_message.py
@@ -309,9 +309,7 @@ class BroadcastMessage(BaseBroadcast):
         alert_summary,
         phone_estimate,
         duration,
-        approx_bleed_in_m,
         wkt,
-        wkt_with_bleed
     ):
         broadcast_message_api_client.send_alert_summary_email(
             service_id=service_id,
@@ -322,9 +320,7 @@ class BroadcastMessage(BaseBroadcast):
             alert_summary=alert_summary,
             phone_estimate=phone_estimate,
             duration=duration,
-            approx_bleed_in_m=approx_bleed_in_m,
             wkt=wkt,
-            wkt_with_bleed=wkt_with_bleed,
         )
 
 

--- a/app/notify_client/broadcast_message_api_client.py
+++ b/app/notify_client/broadcast_message_api_client.py
@@ -122,7 +122,19 @@ class BroadcastMessageAPIClient(AdminAPIClient):
         return self.get(f"/service/{service_id}/broadcast-message/{broadcast_message_id}/provider-statuses")
 
     def send_alert_summary_email(
-        self, *, service_id, broadcast_message_id, geojson, cap_xml, ibag_xml, alert_summary, phone_estimate, duration
+        self,
+        *,
+        service_id,
+        broadcast_message_id,
+        geojson,
+        cap_xml,
+        ibag_xml,
+        alert_summary,
+        phone_estimate,
+        duration,
+        approx_bleed_in_m,
+        wkt,
+        wkt_with_bleed,
     ):
         """
         Send alert email summary to service contacts
@@ -141,6 +153,12 @@ class BroadcastMessageAPIClient(AdminAPIClient):
             data.update(phone_estimate=phone_estimate)
         if duration:
             data.update(duration=duration)
+        if approx_bleed_in_m:
+            data.update(approx_bleed_in_m=approx_bleed_in_m)
+        if wkt:
+            data.update(wkt=wkt)
+        if wkt_with_bleed:
+            data.update(wkt_with_bleed=wkt_with_bleed)
 
         data = _attach_current_user(data)
 

--- a/app/notify_client/broadcast_message_api_client.py
+++ b/app/notify_client/broadcast_message_api_client.py
@@ -132,9 +132,7 @@ class BroadcastMessageAPIClient(AdminAPIClient):
         alert_summary,
         phone_estimate,
         duration,
-        approx_bleed_in_m,
         wkt,
-        wkt_with_bleed,
     ):
         """
         Send alert email summary to service contacts
@@ -153,12 +151,8 @@ class BroadcastMessageAPIClient(AdminAPIClient):
             data.update(phone_estimate=phone_estimate)
         if duration:
             data.update(duration=duration)
-        if approx_bleed_in_m:
-            data.update(approx_bleed_in_m=approx_bleed_in_m)
         if wkt:
             data.update(wkt=wkt)
-        if wkt_with_bleed:
-            data.update(wkt_with_bleed=wkt_with_bleed)
 
         data = _attach_current_user(data)
 

--- a/app/templates/views/broadcast/email-summary.html
+++ b/app/templates/views/broadcast/email-summary.html
@@ -57,6 +57,7 @@
             <li>areas.geojson - areas covered by this alert, in geoJSON format</li>
             <li>areas.cap.xml - areas covered by this alert, in CAP XML format</li>
             <li>areas.ibag.xml - areas covered by this alert, in IBAG XML format</li>
+            <li>areas.jpg - map image of areas covered by this alert</li>
           </ul>
         </p>
 

--- a/app/utils/broadcast.py
+++ b/app/utils/broadcast.py
@@ -712,17 +712,13 @@ def generate_geojson(broadcast_message):
     return geojson
 
 
-def generate_wkt(broadcast_message, with_bleed=False):
+def generate_wkt(broadcast_message):
     areas = broadcast_message.areas
     geoms = []
 
+    # Iterate through all areas in broadcast message and combine them
     for area in areas:
-        if with_bleed:
-            # Get the bleed polygon geometry
-            wkt_str = area.as_wkt_geometry_with_bleed
-        else:
-            # Get the normal polygon geometry
-            wkt_str = area.as_wkt_geometry
+        wkt_str = area.as_wkt_geometry
 
         geoms.append(wkt.loads(wkt_str))
 

--- a/app/utils/broadcast.py
+++ b/app/utils/broadcast.py
@@ -714,6 +714,11 @@ def generate_geojson(broadcast_message):
 
 def generate_wkt(broadcast_message):
     areas = broadcast_message.areas
+
+    # No areas return None
+    if not areas:
+        return None
+
     geoms = []
 
     # Iterate through all areas in broadcast message and combine them
@@ -721,6 +726,10 @@ def generate_wkt(broadcast_message):
         wkt_str = area.as_wkt_geometry
 
         geoms.append(wkt.loads(wkt_str))
+
+    # No valid geometries return None
+    if not geoms:
+        return None
 
     merged = unary_union(geoms)
     return merged.wkt

--- a/app/utils/broadcast.py
+++ b/app/utils/broadcast.py
@@ -7,7 +7,7 @@ from emergency_alerts_utils.xml.cap import convert_utc_datetime_to_cap_standard_
 from emergency_alerts_utils.xml.common import HEADLINE
 from flask import redirect, render_template, request, url_for
 from postcode_validator.uk.uk_postcode_validator import UKPostcode
-from shapely import Point
+from shapely import Point, wkt
 from shapely.geometry import MultiPolygon, Polygon
 from shapely.ops import unary_union
 
@@ -710,6 +710,24 @@ def generate_geojson(broadcast_message):
         ],
     }
     return geojson
+
+
+def generate_wkt(broadcast_message, with_bleed=False):
+    areas = broadcast_message.areas
+    geoms = []
+
+    for area in areas:
+        if with_bleed:
+            # Get the bleed polygon geometry
+            wkt_str = area.as_wkt_geometry_with_bleed
+        else:
+            # Get the normal polygon geometry
+            wkt_str = area.as_wkt_geometry
+
+        geoms.append(wkt.loads(wkt_str))
+
+    merged = unary_union(geoms)
+    return merged.wkt
 
 
 def generate_unsigned_xml(broadcast_message, xml_type):

--- a/tests/app/notify_client/test_broadcast_message_client.py
+++ b/tests/app/notify_client/test_broadcast_message_client.py
@@ -1,3 +1,5 @@
+import pytest
+
 from app.notify_client.broadcast_message_api_client import BroadcastMessageAPIClient
 
 
@@ -102,4 +104,51 @@ def test_reject_broadcast_message_status_with_rejection_reason(mocker):
     mock_post.assert_called_once_with(
         "/service/12345/broadcast-message/67890/status-with-reason",
         data={"created_by": "1", "status": "cancelled", "rejection_reason": "This is a test rejection reason."},
+    )
+
+
+@pytest.mark.parametrize(
+    "wkt_value",
+    [
+        # No WKT → should not appear in payload
+        None,
+        # Simple polygon
+        "POLYGON ((-0.1400 51.5150,-0.1400 51.4950,-0.1000 51.4950,-0.1000 51.5150,-0.1400 51.5150))",
+        # Multipolygon wrapper
+        "MULTIPOLYGON (((-0.1400 51.5150,-0.1400 51.4950,-0.1000 51.4950,-0.1000 51.5150,-0.1400 51.5150)))",
+    ],
+)
+def test_send_alert_summary_email(mocker, wkt_value):
+    client = BroadcastMessageAPIClient()
+    mocker.patch("app.notify_client.current_user", id="1")
+    mock_post = mocker.patch("app.notify_client.broadcast_message_api_client.BroadcastMessageAPIClient.post")
+
+    geojson = {"type": "Point", "coordinates": [0, 0]}
+    cap_xml = "<cap/>"
+    ibag_xml = "<ibag/>"
+
+    client.send_alert_summary_email(
+        service_id="12345",
+        broadcast_message_id="67890",
+        geojson=geojson,
+        cap_xml=cap_xml,
+        ibag_xml=ibag_xml,
+        alert_summary="summary",
+        phone_estimate="less than 1 million",
+        duration="30 minutes",
+        wkt=wkt_value,
+    )
+
+    mock_post.assert_called_once_with(
+        "/service/12345/broadcast-message/67890/alert-summary-email",
+        data={
+            "geojson": geojson,
+            "cap_xml": cap_xml,
+            "ibag_xml": ibag_xml,
+            "alert_summary": "summary",
+            "phone_estimate": "less than 1 million",
+            "duration": "30 minutes",
+            **({"wkt": wkt_value} if wkt_value else {}),
+            "created_by": "1",
+        },
     )


### PR DESCRIPTION
- Add methods to generate WKT for all areas in a broadcast
- Pass WKT through to API when calling send email summary end point.
- Add missing notify client unit tests.

`api:EAS-1325-send-map-preview-with-summary-email`